### PR TITLE
Add bootstrapping from localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@
 
 Add Feature Flags to your Next.js application with a single React Hook. This package integrates your Next.js application with HappyKit Flags. Create a free [happykit.dev](https://happykit.dev/signup) account to get started.
 
+**Key Features**
+
+- written for Next.js
+- integrate using a simple `useFlags` hook
+- only 1 kB in size
+- extremely fast flag responses (under 100ms on average)
+- target individual users
+- server-side rendering support
+- static site generation support (redeploy your website on flag changes)
+
 <details><br /><br />
   <summary><b>Want to see a demo?</b></summary>
 
@@ -24,7 +34,10 @@ Add Feature Flags to your Next.js application with a single React Hook. This pac
 
 <br />
 
-- [Key Features](#key-features)
+---
+
+<br />
+
 - [Installation](#installation)
 - [Setup](#setup)
 - [Basic Usage](#basic-usage)
@@ -48,15 +61,7 @@ Add Feature Flags to your Next.js application with a single React Hook. This pac
     - [Custom Flag Type](#custom-flag-type)
   - [Code splitting](#code-splitting)
 
-## Key Features
-
-- written for Next.js
-- integrate using a simple `useFlags` hook
-- only 1 kB in size
-- extremely fast flag responses (under 100ms on average)
-- target individual users
-- server-side rendering support
-- static site generation support (redeploy your website on flag changes)
+<br />
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ export const getServerSideProps = async () => {
 - `configure(options)`
   - `options.clientId` _(string)_ _required_: Your HappyKit Flags Client Id
   - `options.defaultFlags` _(object)_ _optional_: Key-value pairs of flags and their values. These values are used as fallbacks in `useFlags` and `getFlags`. The fallbacks are used while the actual flags are loaded, in case a flag is missing or when the request loading the flags fails for unexpected reasons. If you don't declare `defaultFlags`, then the flag values will be `undefined`.
+  - `options.disableCache` _(boolean)_ _optional_: Pass `true` to turn off the client-side cache. The cache is persisted to `localStorage` and persists across page loads. Even with an enabled cache, all flags will get revalidated in [`stale-while-revalidate`](https://tools.ietf.org/html/rfc5861) fashion.
 
 ### `useFlags`
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ export const getServerSideProps = async () => {
 
 - `useFlag(options)`
   - `options.user` _(object)_ _optional_: A user to load the flags for. The user you pass here will be stored in HappyKit for future reference and [individual targeting](#with-user-targeting). A user must at least have a `key`. See the supported user attributes [here](#supported-user-attributes).
-  - `options.initialFlags` _(object)_ _optional_: In case you preloaded user flags during server-side rendering or static site generation, provide the flags as `initialFlags`. The client will then skip the initial request and use the provided flags instead. This allows you to get rid of loading states on the client.
+  - `options.initialFlags` _(object)_ _optional_: In case you preloaded your flags during server-side rendering using `getFlags()`, provide the flags as `initialFlags`. The client will then skip the initial request and use the provided flags instead. This allows you to get rid of loading states on the client.
   - `options.revalidateOnFocus` _(object)_ _optional_: By default, the client will revalidate all feature flags when the browser window regains focus. Pass `revalidateOnFocus: false` to skip this behaviour.
 
 This function returns an object containing the requested flags.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Add Feature Flags to your Next.js application with a single React Hook. This pac
 **Key Features**
 
 - written for Next.js
-- integrate using a simple `useFlags` hook
+- integrate using a simple `useFlags()` hook
 - only 1 kB in size
-- extremely fast flag responses (under 100ms on average)
-- target individual users
+- extremely fast flag responses (~50ms)
+- supports individual user targeting
 - server-side rendering support
 - static site generation support (redeploy your website on flag changes)
 

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -10,8 +10,8 @@ type Flags = {
 };
 
 configure<Partial<Flags>>({
-  endpoint: 'http://localhost:8787/',
-  clientId: 'flags_pub_272357356657967622',
+  // endpoint: 'http://localhost:8787/',
+  clientId: 'flags_pub_277203581177692685',
   defaultFlags: { booleanFlag: true },
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,35 @@ import * as React from 'react';
 export type Flags = { [key: string]: boolean | number | string | undefined };
 
 export type FlagConfig<F extends Flags = Flags> = {
+  /**
+   * Your HappyKit Flags Client Id.
+   *
+   * It should look similar to `flags_pub_277203581177692685`.
+   *
+   * You can use that value if you just want to play around.
+   * You will receive one flag called `dog` which is turned on.
+   */
   clientId?: string;
+  /**
+   * This is internal and you don't need to provide it.
+   *
+   * It defines where the Flags are loaded from.
+   */
   endpoint: string;
+  /**
+   * Key-value pairs of flags and their values. These values are used as
+   * fallbacks in `useFlags` and `getFlags`. The fallbacks are used while the
+   * actual flags are loaded, in case a flag is missing or when the request
+   * loading the flags fails for unexpected reasons. If you don't declare
+   * `defaultFlags`, then the flag values will be `undefined`.
+   */
   defaultFlags?: F;
+  /**
+   * Pass `true` to turn off the client-side cache.
+   * The cache is persisted to `localStorage` and persists across page loads.
+   * Even with an enabled cache, all flags will get revalidated in
+   * [`stale-while-revalidate`](https://tools.ietf.org/html/rfc5861) fashion.
+   */
   disableCache?: boolean;
 };
 
@@ -20,8 +46,22 @@ export type FlagUserAttributes = {
 };
 
 export type FlagOptions<F extends Flags> = {
+  /**
+   * This is the flag user which the flags will be evaluated for.
+   */
   user?: FlagUserAttributes;
+  /**
+   * In case you preloaded your flags during server-side rendering using
+   * `getFlags()`, provide the flags as `initialFlags`.
+   * The client will then skip the initial request and use the provided flags
+   * instead.
+   * This allows you to get rid of loading states on the client.
+   */
   initialFlags?: F;
+  /**
+   * By default, the client will revalidate all feature flags when the browser
+   * window regains focus. Pass `false` to skip this behaviour.
+   */
   revalidateOnFocus?: boolean;
 };
 

--- a/test/index.client.test.tsx
+++ b/test/index.client.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import '@testing-library/jest-dom';
 import * as React from 'react';
 import 'jest-fetch-mock';
-import { useFlags, getFlags, configure, _resetConfig } from '../src';
+import { useFlags, getFlags, configure, _reset } from '../src';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 
@@ -12,8 +12,9 @@ const fakeResponse = {
 };
 
 beforeEach(() => {
-  _resetConfig();
+  _reset();
   fetchMock.resetMocks();
+  window.localStorage.removeItem('happykit_flags');
 });
 
 describe('exports', () => {
@@ -39,6 +40,7 @@ describe('useFlags', () => {
   it('posts to the flags endpoint', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() => useFlags());
     // flags are an empty object until the first response arrives
     expect(result.current).toEqual({});
@@ -50,11 +52,19 @@ describe('useFlags', () => {
       body: '{"envKey":"foo"}',
       method: 'POST',
     });
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+      })
+    );
   });
 
   it('forwards the given user', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() =>
       useFlags({ user: { key: 'user_key_1' } })
     );
@@ -65,11 +75,20 @@ describe('useFlags', () => {
       method: 'POST',
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'user_key_1',
+      })
+    );
   });
 
   it('strips unknown attributes before forwarding a given user', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() =>
       useFlags({
         user: {
@@ -85,11 +104,20 @@ describe('useFlags', () => {
       method: 'POST',
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'user_key_1',
+      })
+    );
   });
 
   it('forwards all supported user attributes', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const user = {
       key: 'user_key_1',
       email: 'test@mail.com',
@@ -105,12 +133,21 @@ describe('useFlags', () => {
       method: 'POST',
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'user_key_1',
+      })
+    );
   });
 
   it('merges application-wide default flag values in', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     const defaultFlags = { xzibit: true };
     configure({ clientId: 'foo', defaultFlags });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() => useFlags());
     await waitForNextUpdate();
     expect(result.current).toEqual({ aFlag: true, ...defaultFlags });
@@ -119,6 +156,14 @@ describe('useFlags', () => {
       method: 'POST',
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        // the default flags are not persisted, as they'll be added anyways
+        flags: { aFlag: true },
+      })
+    );
   });
 
   it('uses actual values over default values', async () => {
@@ -127,6 +172,7 @@ describe('useFlags', () => {
       fakeResponse.options
     );
     configure({ clientId: 'foo', defaultFlags: { xzibit: true } });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() => useFlags());
     // default value as no response was given yet
     expect(result.current).toEqual({ xzibit: true });
@@ -138,15 +184,24 @@ describe('useFlags', () => {
       method: 'POST',
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true, xzibit: false },
+      })
+    );
   });
 
   it('does not fetch on mount when initial flag values were provided', async () => {
     fetchMock.mockOnce();
     const initialFlags = { xzibit: true };
     configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result } = renderHook(() => useFlags({ initialFlags }));
     expect(result.current).toEqual(initialFlags);
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
   });
 
   it('refetches flags and overwrites them when the window regains focus', async () => {
@@ -155,6 +210,7 @@ describe('useFlags', () => {
       fakeResponse.options
     );
     configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const initialFlags = { xzibit: true };
     const Page = () => {
       const flags = useFlags<{ aFlag?: string; xzibit: boolean }>({
@@ -169,6 +225,8 @@ describe('useFlags', () => {
       expect(screen.queryByText('waiting')).toBeInTheDocument();
     });
 
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
+
     fireEvent.blur(window);
     fireEvent.focus(window);
 
@@ -181,14 +239,22 @@ describe('useFlags', () => {
       method: 'POST',
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true, xzibit: false },
+      })
+    );
   });
 
-  it('does not refetch on focus when revalidateOnFocus is set', async () => {
+  it('does not refetch on focus when revalidateOnFocus is disabled', async () => {
     fetchMock.mockOnce(
       JSON.stringify({ aFlag: true, xzibit: false }),
       fakeResponse.options
     );
     configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
     const initialFlags = { xzibit: true };
     const Page = () => {
       const flags = useFlags<{ aFlag?: string; xzibit: boolean }>({
@@ -208,6 +274,213 @@ describe('useFlags', () => {
     fireEvent.focus(window);
 
     expect(fetchMock).toHaveBeenCalledTimes(0);
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
+  });
+
+  it('only fetches once when the hook is called with the same params while another fetch for those params is already in progress', async () => {
+    fetchMock.mockOnce(
+      JSON.stringify({ someFlag: true }),
+      fakeResponse.options
+    );
+    configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
+    const Page = () => {
+      const flagsA = useFlags<{ someFlag?: string }>();
+      const flagsB = useFlags<{ someFlag?: string }>();
+
+      return (
+        <ul>
+          <li>{flagsA.someFlag ? 'a: hello' : 'a: waiting'}</li>
+          <li>{flagsB.someFlag ? 'b: hello' : 'b: waiting'}</li>
+        </ul>
+      );
+    };
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('a: hello')).toBeInTheDocument();
+      expect(screen.queryByText('b: hello')).toBeInTheDocument();
+    });
+
+    // only called once even though the hook is used twice
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preloads hooks from cache after initial render and updates cache with new values when no user is set', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo' });
+
+    // prepare localStorage
+    localStorage.setItem(
+      'happykit_flags',
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: false, bFlag: false },
+      })
+    );
+
+    const { result, waitForNextUpdate } = renderHook(() => useFlags());
+    expect(result.current).toEqual({ aFlag: false, bFlag: false });
+    await waitForNextUpdate();
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({ envKey: 'foo' }),
+      method: 'POST',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+      })
+    );
+  });
+  it('preloads hooks from cache after initial render and updates cache with new values when a user key is set', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo' });
+
+    // prepare localStorage
+    localStorage.setItem(
+      'happykit_flags',
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: false, bFlag: false },
+        userAttributesKey: 'user_A',
+      })
+    );
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlags({ user: { key: 'user_A' } })
+    );
+    expect(result.current).toEqual({ aFlag: false, bFlag: false });
+    await waitForNextUpdate();
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({ envKey: 'foo', user: { key: 'user_A' } }),
+      method: 'POST',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'user_A',
+      })
+    );
+  });
+
+  it('ignores cached values when the flag user key does not match', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo' });
+
+    // prepare localStorage
+    localStorage.setItem(
+      'happykit_flags',
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: false, bFlag: false },
+        userAttributesKey: 'user_A',
+      })
+    );
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlags({ user: { key: 'user_B' } })
+    );
+    expect(result.current).toEqual({
+      /* no flags since user key did not match */
+    });
+    await waitForNextUpdate();
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({ envKey: 'foo', user: { key: 'user_B' } }),
+      method: 'POST',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'user_B',
+      })
+    );
+  });
+
+  it('ignores cached values when the cache has a user but the hook does not', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo' });
+
+    // prepare localStorage
+    localStorage.setItem(
+      'happykit_flags',
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: false, bFlag: false },
+        userAttributesKey: 'user_A',
+      })
+    );
+
+    const { result, waitForNextUpdate } = renderHook(() => useFlags());
+    expect(result.current).toEqual({
+      /* no flags since user key did not match */
+    });
+    await waitForNextUpdate();
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({ envKey: 'foo' }),
+      method: 'POST',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+      })
+    );
+  });
+
+  it('ignores cached values when the cache has no user but the hook has one', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo' });
+
+    // prepare localStorage
+    localStorage.setItem(
+      'happykit_flags',
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: false, bFlag: false },
+      })
+    );
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlags({ user: { key: 'user_B' } })
+    );
+    expect(result.current).toEqual({
+      /* no flags since user key did not match */
+    });
+    await waitForNextUpdate();
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({ envKey: 'foo', user: { key: 'user_B' } }),
+      method: 'POST',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'user_B',
+      })
+    );
   });
 });
 

--- a/test/index.server.test.tsx
+++ b/test/index.server.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import 'jest-fetch-mock';
-import { getFlags, configure, _resetConfig } from '../src';
+import { getFlags, configure, _reset } from '../src';
 
 const fakeResponse = {
   body: JSON.stringify({ aFlag: true }),
@@ -10,7 +10,7 @@ const fakeResponse = {
 };
 
 beforeEach(() => {
-  _resetConfig();
+  _reset();
   fetchMock.resetMocks();
 });
 


### PR DESCRIPTION
- adds automatic bootstrapping from `localStorage`
- adds `disableCache` option to disable this bootstrapping
- adds request parallelisation
  - when a flag request is triggered while another flag request is already in progress, only one request is made and both hooks are resolved with that value
  - this is only done in case the requests match exactly (same endpoint, same user attributes)
  - this is useful in case somebody has multiple `useFlags()` calls spread in their code