### PR TITLE
Make persisting optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,13 @@ export const getServerSideProps = async () => {
 ### `configure`
 
 - `configure(options)`
+
   - `options.clientId` _(string)_ _required_: Your HappyKit Flags Client Id
   - `options.defaultFlags` _(object)_ _optional_: Key-value pairs of flags and their values. These values are used as fallbacks in `useFlags` and `getFlags`. The fallbacks are used while the actual flags are loaded, in case a flag is missing or when the request loading the flags fails for unexpected reasons. If you don't declare `defaultFlags`, then the flag values will be `undefined`.
   - `options.disableCache` _(boolean)_ _optional_: Pass `true` to turn off the client-side cache. The cache is persisted to `localStorage` and persists across page loads. Even with an enabled cache, all flags will get revalidated in [`stale-while-revalidate`](https://tools.ietf.org/html/rfc5861) fashion.
+  - `options.persistUsers` _(boolean)_ _optional_: By default, HappyKit will not store the provided user. Pass `true` to store the provided user in HappyKit Flags. This makes the user available in the HappyKit Flags Dashboard. Persisting a user does not affect flag evaluation.
+
+`configure` sets application-wide defaults. Settings can be overwritten for individual calls with the options passed to `useFlags` and `getFlags`.
 
 ### `useFlags`
 
@@ -143,11 +147,9 @@ export const getServerSideProps = async () => {
   - `options.user` _(object)_ _optional_: A user to load the flags for. The user you pass here will be stored in HappyKit for future reference and [individual targeting](#with-user-targeting). A user must at least have a `key`. See the supported user attributes [here](#supported-user-attributes).
   - `options.initialFlags` _(object)_ _optional_: In case you preloaded your flags during server-side rendering using `getFlags()`, provide the flags as `initialFlags`. The client will then skip the initial request and use the provided flags instead. This allows you to get rid of loading states on the client.
   - `options.revalidateOnFocus` _(object)_ _optional_: By default, the client will revalidate all feature flags when the browser window regains focus. Pass `revalidateOnFocus: false` to skip this behaviour.
-  - `options.persist` _(boolean)_ _optional_: By default, HappyKit will not store the provided user. Pass `true` to store the provided user in HappyKit Flags. This makes the user available in the HappyKit Flags Dashboard. Persisting a user does not affect flag evaluation.
+  - `options.persistUser` _(boolean)_ _optional_: By default, HappyKit will not store the provided user. Pass `true` to store the provided user in HappyKit Flags. This makes the user available in the HappyKit Flags Dashboard. Persisting a user does not affect flag evaluation.
 
 This function returns an object containing the requested flags.
-
-`persist` can be provided to `configure` to set application-wide defaults and to `useFlags` to set the value for individual calls. The options provided to `useFlags` always win. When no value is set,
 
 #### Supported user attributes
 
@@ -163,7 +165,7 @@ Provide any of these attributes to store them in HappyKit. You will be able to u
 
 - `getFlags(options)`
   - `options.user` _(object)_ _optional_: A user to load the flags for. The user you pass here will be stored in HappyKit for future reference. A user must at least have a `key`. See a list of supported user attributes [here](#supported-user-attributes).
-  - `options.persist` _(boolean)_ _optional_: By default, HappyKit will not store the provided user. Pass `true` to store the provided user in HappyKit Flags. This makes the user available in the HappyKit Flags Dashboard. Persisting a user does not affect flag evaluation.
+  - `options.persistUser` _(boolean)_ _optional_: By default, HappyKit will not store the provided user. Pass `true` to store the provided user in HappyKit Flags. This makes the user available in the HappyKit Flags Dashboard. Persisting a user does not affect flag evaluation.
 
 This function returns a promise resolving to an object containing requested flags.
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,11 @@ export const getServerSideProps = async () => {
   - `options.user` _(object)_ _optional_: A user to load the flags for. The user you pass here will be stored in HappyKit for future reference and [individual targeting](#with-user-targeting). A user must at least have a `key`. See the supported user attributes [here](#supported-user-attributes).
   - `options.initialFlags` _(object)_ _optional_: In case you preloaded your flags during server-side rendering using `getFlags()`, provide the flags as `initialFlags`. The client will then skip the initial request and use the provided flags instead. This allows you to get rid of loading states on the client.
   - `options.revalidateOnFocus` _(object)_ _optional_: By default, the client will revalidate all feature flags when the browser window regains focus. Pass `revalidateOnFocus: false` to skip this behaviour.
+  - `options.persist` _(boolean)_ _optional_: By default, HappyKit will not store the provided user. Pass `true` to store the provided user in HappyKit Flags. This makes the user available in the HappyKit Flags Dashboard. Persisting a user does not affect flag evaluation.
 
 This function returns an object containing the requested flags.
+
+`persist` can be provided to `configure` to set application-wide defaults and to `useFlags` to set the value for individual calls. The options provided to `useFlags` always win. When no value is set,
 
 #### Supported user attributes
 
@@ -158,8 +161,9 @@ Provide any of these attributes to store them in HappyKit. You will be able to u
 
 ### `getFlags`
 
-- `getFlags(user)`
-  - `user` _(object)_ _optional_: A user to load the flags for. The user you pass here will be stored in HappyKit for future reference. A user must at least have a `key`. See a list of supported user attributes [here](#supported-user-attributes).
+- `getFlags(options)`
+  - `options.user` _(object)_ _optional_: A user to load the flags for. The user you pass here will be stored in HappyKit for future reference. A user must at least have a `key`. See a list of supported user attributes [here](#supported-user-attributes).
+  - `options.persist` _(boolean)_ _optional_: By default, HappyKit will not store the provided user. Pass `true` to store the provided user in HappyKit Flags. This makes the user available in the HappyKit Flags Dashboard. Persisting a user does not affect flag evaluation.
 
 This function returns a promise resolving to an object containing requested flags.
 
@@ -198,7 +202,7 @@ export default function FooPage(props) {
 
 export const getServerSideProps = async () => {
   const user = { key: 'user-id' };
-  const initialFlags = await getFlags(user);
+  const initialFlags = await getFlags({ user });
   return { props: { user, initialFlags } };
 };
 ```
@@ -360,7 +364,7 @@ export const getServerSideProps = async ({ req, res }) => {
   // preload your user somehow
   const user = await getUser(req);
   // pass the user to getFlags to preload flags for that user
-  const initialFlags = await getFlags(user);
+  const initialFlags = await getFlags({ user });
 
   return { props: { user, initialFlags } };
 };
@@ -493,7 +497,7 @@ export const getServerSideProps = async ({ req, res }) => {
   // preload your user somehow
   const user = await getUser(req);
   // pass the user to getFlags to preload flags for that user
-  const initialFlags = await getFlags(user);
+  const initialFlags = await getFlags({ user });
 
   return { props: { user, initialFlags } };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,18 @@ export type FlagConfig<F extends Flags = Flags> = {
    * [`stale-while-revalidate`](https://tools.ietf.org/html/rfc5861) fashion.
    */
   disableCache?: boolean;
+  /**
+   * Users are not stored in HappyKit Flags by default.
+   *
+   * If you set this option to `true` all users with a `key` attribute will be stored in HappyKit Flags.
+   * Storing users in HappyKit Flags allows you to see the users in the Dashboard.
+   *
+   * This setting only affects whether you see individual users in HappyKit Flags or not.
+   * It does not affect Feature Flag evaluation, percentage based rollouts or anything else.
+   *
+   * You can overwrite this setting per user by passing `{ persist: true }` to `getFlags` or `useFlags`.
+   */
+  persist?: boolean;
 };
 
 export type FlagUserAttributes = {
@@ -63,6 +75,12 @@ export type FlagOptions<F extends Flags> = {
    * window regains focus. Pass `false` to skip this behaviour.
    */
   revalidateOnFocus?: boolean;
+  /**
+   * By default all passed users are stored in HappyKit.
+   *
+   * Pass `persist: true` to store this user in HappyKit.
+   */
+  persist?: boolean;
 };
 
 const defaultConfig: FlagConfig = {
@@ -105,19 +123,19 @@ function toUserAttributes(user: any): FlagUserAttributes | null {
   const userAttributes: FlagUserAttributes = { key: user.key.trim() };
 
   if (typeof user?.email === 'string') {
-    userAttributes['email'] = user.email;
+    userAttributes.email = user.email;
   }
 
   if (typeof user?.name === 'string') {
-    userAttributes['name'] = user.name;
+    userAttributes.name = user.name;
   }
 
   if (typeof user?.avatar === 'string') {
-    userAttributes['avatar'] = user.avatar;
+    userAttributes.avatar = user.avatar;
   }
 
   if (typeof user?.country === 'string') {
-    userAttributes['country'] = user.country;
+    userAttributes.country = user.country;
   }
 
   return userAttributes;
@@ -150,15 +168,18 @@ function shallowEqual(objA: any, objB: any) {
 }
 
 function createBody(
-  clientId: FlagConfig['clientId'],
+  config: Pick<FlagConfig, 'clientId' | 'persist'>,
   userAttributes: FlagUserAttributes | null
 ) {
   const body: {
     envKey: FlagConfig['clientId'];
     user?: FlagUserAttributes;
+    persist?: boolean;
   } = {
-    envKey: clientId,
+    envKey: config.clientId,
   };
+
+  if (config.persist) body.persist = true;
 
   if (userAttributes) body.user = userAttributes;
 
@@ -212,7 +233,7 @@ async function fetchFlags<F extends Flags>({
   try {
     const flags = await queuedFetchFlags<F>(
       config.endpoint,
-      JSON.stringify(createBody(config.clientId, userAttributes))
+      JSON.stringify(createBody(config, userAttributes))
     );
 
     return flags;
@@ -369,7 +390,7 @@ function usePrimitiveFlags<F extends Flags>(
       try {
         const nextFlags = await queuedFetchFlags<F>(
           config.endpoint,
-          JSON.stringify(createBody(config.clientId, userAttributes))
+          JSON.stringify(createBody(config, userAttributes))
         );
 
         if (!nextFlags) return;

--- a/test/index.client.test.tsx
+++ b/test/index.client.test.tsx
@@ -566,33 +566,99 @@ describe('useFlags', () => {
     expect(localStorage.getItem('happykit_flags')).toBeNull();
   });
 
-  // it('sends "persist" when "persist" is set in useFlags', async () => {
-  //   fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
-  //   configure({ clientId: 'foo' });
-  //   expect(localStorage.getItem('happykit_flags')).toBeNull();
-  //   const { result, waitForNextUpdate } = renderHook(() =>
-  //     useFlags({ persist: true })
-  //   );
-  //   // flags are an empty object until the first response arrives
-  //   expect(result.current).toEqual({});
-  //   await waitForNextUpdate();
-  //   // flags are defined from then on
-  //   expect(result.current).toEqual({ aFlag: true });
-  //   expect(fetchMock).toHaveBeenCalledTimes(1);
-  //   expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
-  //     body: JSON.stringify({ envKey: 'foo', persist: true }),
-  //     method: 'POST',
-  //   });
-  //   expect(localStorage.getItem('happykit_flags')).toEqual(
-  //     JSON.stringify({
-  //       endpoint: 'https://happykit.dev/api/flags',
-  //       clientId: 'foo',
-  //       flags: { aFlag: true },
-  //     })
-  //   );
-  // });
+  it('sends "persist" when "persist" is set in useFlags', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlags({ persist: true, user: { key: 'test-user-key' } })
+    );
+    // flags are an empty object until the first response arrives
+    expect(result.current).toEqual({});
+    await waitForNextUpdate();
+    // flags are defined from then on
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({
+        envKey: 'foo',
+        persist: true,
+        user: { key: 'test-user-key' },
+      }),
+      method: 'POST',
+    });
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'test-user-key',
+      })
+    );
+  });
 
   it('sends "persist" when "persist" is set in the global config', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo', persist: true });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlags({ user: { key: 'test-user-key' } })
+    );
+    // flags are an empty object until the first response arrives
+    expect(result.current).toEqual({});
+    await waitForNextUpdate();
+    // flags are defined from then on
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({
+        envKey: 'foo',
+        persist: true,
+        user: { key: 'test-user-key' },
+      }),
+      method: 'POST',
+    });
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'test-user-key',
+      })
+    );
+  });
+
+  it('does not send "persist" when "persist" is set in the global config but overwritten by useFlags', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo', persist: true });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlags({ user: { key: 'test-user-key' }, persist: false })
+    );
+    // flags are an empty object until the first response arrives
+    expect(result.current).toEqual({});
+    await waitForNextUpdate();
+    // flags are defined from then on
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({
+        envKey: 'foo',
+        user: { key: 'test-user-key' },
+      }),
+      method: 'POST',
+    });
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+        userAttributesKey: 'test-user-key',
+      })
+    );
+  });
+
+  it('does not send "persist" when "persist" is set in the global config but no user is provided', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo', persist: true });
     expect(localStorage.getItem('happykit_flags')).toBeNull();
@@ -604,7 +670,33 @@ describe('useFlags', () => {
     expect(result.current).toEqual({ aFlag: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
-      body: JSON.stringify({ envKey: 'foo', persist: true }),
+      body: JSON.stringify({ envKey: 'foo' }),
+      method: 'POST',
+    });
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+      })
+    );
+  });
+
+  it('does not send "persist" when "persist" is set in useFlags but no user is provided', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo' });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFlags({ persist: true })
+    );
+    // flags are an empty object until the first response arrives
+    expect(result.current).toEqual({});
+    await waitForNextUpdate();
+    // flags are defined from then on
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({ envKey: 'foo' }),
       method: 'POST',
     });
     expect(localStorage.getItem('happykit_flags')).toEqual(

--- a/test/index.client.test.tsx
+++ b/test/index.client.test.tsx
@@ -566,12 +566,12 @@ describe('useFlags', () => {
     expect(localStorage.getItem('happykit_flags')).toBeNull();
   });
 
-  it('sends "persist" when "persist" is set in useFlags', async () => {
+  it('sends "persistUser" when "persistUser" is set in useFlags', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
     expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useFlags({ persist: true, user: { key: 'test-user-key' } })
+      useFlags({ persistUser: true, user: { key: 'test-user-key' } })
     );
     // flags are an empty object until the first response arrives
     expect(result.current).toEqual({});
@@ -582,7 +582,7 @@ describe('useFlags', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
       body: JSON.stringify({
         envKey: 'foo',
-        persist: true,
+        persistUser: true,
         user: { key: 'test-user-key' },
       }),
       method: 'POST',
@@ -597,9 +597,9 @@ describe('useFlags', () => {
     );
   });
 
-  it('sends "persist" when "persist" is set in the global config', async () => {
+  it('sends "persistUser" when "persistUsers" is set in the global config', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
-    configure({ clientId: 'foo', persist: true });
+    configure({ clientId: 'foo', persistUsers: true });
     expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() =>
       useFlags({ user: { key: 'test-user-key' } })
@@ -613,7 +613,7 @@ describe('useFlags', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
       body: JSON.stringify({
         envKey: 'foo',
-        persist: true,
+        persistUser: true,
         user: { key: 'test-user-key' },
       }),
       method: 'POST',
@@ -628,12 +628,12 @@ describe('useFlags', () => {
     );
   });
 
-  it('does not send "persist" when "persist" is set in the global config but overwritten by useFlags', async () => {
+  it('does not send "persistUser" when "persistUsers" is set in the global config but overwritten by useFlags', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
-    configure({ clientId: 'foo', persist: true });
+    configure({ clientId: 'foo', persistUsers: true });
     expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useFlags({ user: { key: 'test-user-key' }, persist: false })
+      useFlags({ user: { key: 'test-user-key' }, persistUser: false })
     );
     // flags are an empty object until the first response arrives
     expect(result.current).toEqual({});
@@ -658,9 +658,9 @@ describe('useFlags', () => {
     );
   });
 
-  it('does not send "persist" when "persist" is set in the global config but no user is provided', async () => {
+  it('does not send "persistUser" when "persistUsers" is set in the global config but no user is provided', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
-    configure({ clientId: 'foo', persist: true });
+    configure({ clientId: 'foo', persistUsers: true });
     expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() => useFlags());
     // flags are an empty object until the first response arrives
@@ -682,12 +682,12 @@ describe('useFlags', () => {
     );
   });
 
-  it('does not send "persist" when "persist" is set in useFlags but no user is provided', async () => {
+  it('does not send "persistUser" when "persistUser" is set in useFlags but no user is provided', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
     expect(localStorage.getItem('happykit_flags')).toBeNull();
     const { result, waitForNextUpdate } = renderHook(() =>
-      useFlags({ persist: true })
+      useFlags({ persistUser: true })
     );
     // flags are an empty object until the first response arrives
     expect(result.current).toEqual({});

--- a/test/index.client.test.tsx
+++ b/test/index.client.test.tsx
@@ -366,6 +366,7 @@ describe('useFlags', () => {
       })
     );
   });
+
   it('preloads hooks from cache after initial render and updates cache with new values when a user key is set', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
@@ -563,6 +564,56 @@ describe('useFlags', () => {
 
     // no changes to localStorage
     expect(localStorage.getItem('happykit_flags')).toBeNull();
+  });
+
+  // it('sends "persist" when "persist" is set in useFlags', async () => {
+  //   fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+  //   configure({ clientId: 'foo' });
+  //   expect(localStorage.getItem('happykit_flags')).toBeNull();
+  //   const { result, waitForNextUpdate } = renderHook(() =>
+  //     useFlags({ persist: true })
+  //   );
+  //   // flags are an empty object until the first response arrives
+  //   expect(result.current).toEqual({});
+  //   await waitForNextUpdate();
+  //   // flags are defined from then on
+  //   expect(result.current).toEqual({ aFlag: true });
+  //   expect(fetchMock).toHaveBeenCalledTimes(1);
+  //   expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+  //     body: JSON.stringify({ envKey: 'foo', persist: true }),
+  //     method: 'POST',
+  //   });
+  //   expect(localStorage.getItem('happykit_flags')).toEqual(
+  //     JSON.stringify({
+  //       endpoint: 'https://happykit.dev/api/flags',
+  //       clientId: 'foo',
+  //       flags: { aFlag: true },
+  //     })
+  //   );
+  // });
+
+  it('sends "persist" when "persist" is set in the global config', async () => {
+    fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
+    configure({ clientId: 'foo', persist: true });
+    expect(localStorage.getItem('happykit_flags')).toBeNull();
+    const { result, waitForNextUpdate } = renderHook(() => useFlags());
+    // flags are an empty object until the first response arrives
+    expect(result.current).toEqual({});
+    await waitForNextUpdate();
+    // flags are defined from then on
+    expect(result.current).toEqual({ aFlag: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
+      body: JSON.stringify({ envKey: 'foo', persist: true }),
+      method: 'POST',
+    });
+    expect(localStorage.getItem('happykit_flags')).toEqual(
+      JSON.stringify({
+        endpoint: 'https://happykit.dev/api/flags',
+        clientId: 'foo',
+        flags: { aFlag: true },
+      })
+    );
   });
 });
 

--- a/test/index.server.test.tsx
+++ b/test/index.server.test.tsx
@@ -124,36 +124,36 @@ describe('getFlags', () => {
     });
   });
 
-  it('sends "persist" when "persist" is set in the global config', async () => {
+  it('sends "persistUser" when "persistUsers" is set in the global config', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
-    configure({ clientId: 'foo', persist: true });
+    configure({ clientId: 'foo', persistUsers: true });
     const user = { key: 'user_key_1' };
     const flags = await getFlags({ user });
     expect(flags).toEqual({ aFlag: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
-      body: JSON.stringify({ envKey: 'foo', persist: true, user }),
+      body: JSON.stringify({ envKey: 'foo', persistUser: true, user }),
       method: 'POST',
     });
   });
 
-  it('sends "persist" when "persist" is set in getFlags', async () => {
+  it('sends "persistUser" when "persistUser" is set in getFlags', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
     const user = { key: 'user_key_1' };
-    const flags = await getFlags({ user, persist: true });
+    const flags = await getFlags({ user, persistUser: true });
     expect(flags).toEqual({ aFlag: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
-      body: JSON.stringify({ envKey: 'foo', persist: true, user }),
+      body: JSON.stringify({ envKey: 'foo', persistUser: true, user }),
       method: 'POST',
     });
   });
 
-  it('does not pass "persist" when "persist" is set in getFlags and no user is given', async () => {
+  it('does not pass "persistUser" when "persistUser" is set in getFlags and no user is given', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
-    const flags = await getFlags({ persist: true });
+    const flags = await getFlags({ persistUser: true });
     expect(flags).toEqual({ aFlag: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
@@ -162,10 +162,10 @@ describe('getFlags', () => {
     });
   });
 
-  it('does not send "persist" when "persist" is set in the global config but overwritten by getFlags', async () => {
+  it('does not send "persistUser" when "persistUser" is set in the global config but overwritten by getFlags', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
-    configure({ clientId: 'foo', persist: true });
-    const flags = await getFlags({ persist: false });
+    configure({ clientId: 'foo', persistUsers: true });
+    const flags = await getFlags({ persistUser: false });
     expect(flags).toEqual({ aFlag: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {
@@ -174,9 +174,9 @@ describe('getFlags', () => {
     });
   });
 
-  it('does not send "persist" when "persist" is set in the global config but no user is provided', async () => {
+  it('does not send "persistUser" when "persistUsers" is set in the global config but no user is provided', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
-    configure({ clientId: 'foo', persist: true });
+    configure({ clientId: 'foo', persistUsers: true });
     const flags = await getFlags();
     expect(flags).toEqual({ aFlag: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -186,10 +186,10 @@ describe('getFlags', () => {
     });
   });
 
-  it('does not send "persist" when "persist" is set in getFlags but no user is provided', async () => {
+  it('does not send "persistUser" when "persistUser" is set in getFlags but no user is provided', async () => {
     fetchMock.mockOnce(fakeResponse.body, fakeResponse.options);
     configure({ clientId: 'foo' });
-    const flags = await getFlags({ persist: true });
+    const flags = await getFlags({ persistUser: true });
     expect(flags).toEqual({ aFlag: true });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('https://happykit.dev/api/flags', {


### PR DESCRIPTION
## Summary

- breaks `getFlags` by changing it from `getFlags(user)` to `getFlags({ user })`
- introduces a `persistUser` option to `useFlags` and `getFlags` and makes persisting users in HappyKit opt-in
- introduces an application-wide default setting called `persistUsers` to `configure()`

## Details

When you send a user to HappyKit with `useFlags({ user: {key: "xxx"} })` that user is stored in HappyKit, along with all the provided attributes. This is done so you're able to see the users of your flags in the HappyKit dashboard. 

**Whether you persist a user or not doesn't affect how that users flags are evaluated.** It is purely done to provide more complete data in the HappyKit Flags Dashboard.

Until now all users were always stored in HappyKit Flags automatically. However, sites with high user counts wouldn't want to flood their dashboard with all their users. Instead, they might want to send individual users only (like team members).

To enable this, persistent users are now opt-in. You can set this via `configure({ persistUsers: true })` globally, or on a per-user basis via `useFlags({ persistUser: true, user: { key: "xxx" } })`. For example, you can use this to only persist team members by setting `persistUser` on a per-user basis: `useFlags({ persistUser: isTeamMember, user: { key: "xxx" } })`.

`getFlags` supports the `persistUser` option too. To enable this, `getFlags` now accepts an object similar to `useFlags`.

## BREAKING CHANGE
- breaks `getFlags` by changing the API from `getFlags(user)` to `getFlags({ user })`