### PR TITLE
remove static

### DIFF
--- a/package/src/client.csr.spec.ts
+++ b/package/src/client.csr.spec.ts
@@ -40,7 +40,6 @@ describe("when cookie is not set", () => {
         expect(body).toEqual({
           user: null,
           traits: null,
-          static: false,
           visitorKey: expect.any(String),
         });
 
@@ -129,7 +128,6 @@ describe("when cookie is set", () => {
           visitorKey: visitorKeyInCookie,
           user: null,
           traits: null,
-          static: false,
         },
       },
       {
@@ -221,7 +219,6 @@ describe("stories", () => {
           expect(body).toEqual({
             user: null,
             traits: null,
-            static: false,
             visitorKey: expect.any(String),
           });
 
@@ -258,7 +255,6 @@ describe("stories", () => {
             visitorKey: generatedVisitorKey,
             user: { key: "george" },
             traits: null,
-            static: false,
           },
         },
         {

--- a/package/src/client.ssg.spec.ts
+++ b/package/src/client.ssg.spec.ts
@@ -36,7 +36,6 @@ describe("when cookie is not set", () => {
         generatedVisitorKey = body.visitorKey;
 
         expect(body).toEqual({
-          static: false,
           traits: null,
           user: null,
           visitorKey: expect.any(String),
@@ -67,7 +66,6 @@ describe("when cookie is not set", () => {
           visitorKey: null,
           user: null,
           traits: null,
-          static: true,
         },
       },
       outcome: {
@@ -187,11 +185,10 @@ describe("when cookie is set", () => {
       {
         url: "https://happykit.dev/api/flags/flags_pub_000000",
         body: {
-          // false because this is the request of the client afer hydration,
-          // not the one during static site generation
-          static: false,
           traits: null,
           user: null,
+          // not static because this is the request of the client afer hydration,
+          // not the one during static site generation
           visitorKey: visitorKeyInCookie,
         },
       },
@@ -216,7 +213,6 @@ describe("when cookie is set", () => {
           visitorKey: null,
           user: null,
           traits: null,
-          static: true,
         },
       },
       outcome: {

--- a/package/src/client.ssr.spec.ts
+++ b/package/src/client.ssr.spec.ts
@@ -34,7 +34,6 @@ describe("when visitorKey is not set in cookie", () => {
           visitorKey: generatedVisitorKey,
           user: null,
           traits: null,
-          static: false,
         },
       },
       outcome: {
@@ -112,7 +111,6 @@ describe("when visitorKey is set in cookie", () => {
           visitorKey: visitorKeyInCookie,
           user: null,
           traits: null,
-          static: false,
         },
       },
       outcome: {

--- a/package/src/client.ts
+++ b/package/src/client.ts
@@ -318,7 +318,6 @@ function getInput<F extends Flags>({
       visitorKey: cookie || visitorKeyInState || generatedVisitorKey,
       user,
       traits,
-      static: false,
     },
   };
 }
@@ -326,7 +325,7 @@ function getInput<F extends Flags>({
 function omitStaticDifferences(input: Input) {
   return {
     ...input,
-    requestBody: { ...input.requestBody, static: null, visitorKey: null },
+    requestBody: { ...input.requestBody, visitorKey: null },
   };
 }
 
@@ -342,7 +341,7 @@ function isAlmostEqual(
 ): boolean {
   // special treatment when the current input is static
   // in this case, we ignore the static and visitorKey properties
-  return currentInput?.requestBody.static
+  return currentInput && !currentInput.requestBody.visitorKey
     ? deepEqual(
         omitStaticDifferences(currentInput),
         omitStaticDifferences(nextInput)
@@ -418,9 +417,9 @@ export function useFlags<F extends Flags = Flags>(
           outcome: initialFlagState.outcome,
         },
         // revalidate only if the initial state was for a static render
-        initialFlagState.input.requestBody.static
-          ? [{ effect: "revalidate-input", input }]
-          : [],
+        initialFlagState.input.requestBody.visitorKey
+          ? []
+          : [{ effect: "revalidate-input", input }],
       ];
     }
   );
@@ -592,7 +591,7 @@ export function useFlags<F extends Flags = Flags>(
           data: state.outcome.data,
           error: null,
           fetching: false,
-          settled: !state.input.requestBody.static,
+          settled: Boolean(state.input.requestBody.visitorKey),
           revalidate,
           visitorKey: state.input.requestBody.visitorKey,
         } as SucceededFlagBag<F>;
@@ -605,7 +604,7 @@ export function useFlags<F extends Flags = Flags>(
           data: state.outcome.data,
           error: null,
           fetching: true,
-          settled: !state.input.requestBody.static,
+          settled: Boolean(state.input.requestBody.visitorKey),
           revalidate,
           visitorKey: state.input.requestBody.visitorKey,
         } as RevalidatingAfterSuccessFlagBag<F>;
@@ -620,7 +619,7 @@ export function useFlags<F extends Flags = Flags>(
           data: null,
           error: state.outcome.error,
           fetching: false,
-          settled: !state.input.requestBody.static,
+          settled: Boolean(state.input.requestBody.visitorKey),
           revalidate,
           visitorKey: state.input.requestBody.visitorKey,
         } as FailedFlagBag<F>;
@@ -635,7 +634,7 @@ export function useFlags<F extends Flags = Flags>(
           data: null,
           error: state.outcome.error,
           fetching: true,
-          settled: !state.input.requestBody.static,
+          settled: Boolean(state.input.requestBody.visitorKey),
           revalidate,
           visitorKey: state.input.requestBody.visitorKey,
         } as RevalidatingAfterErrorFlagBag<F>;

--- a/package/src/edge.spec.ts
+++ b/package/src/edge.spec.ts
@@ -52,7 +52,6 @@ describe("middleware", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: false,
             traits: { teamMember: true },
             user: null,
             visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -85,7 +84,6 @@ describe("middleware", () => {
             endpoint: "https://happykit.dev/api/flags",
             envKey: "flags_pub_000000",
             requestBody: {
-              static: false,
               traits: { teamMember: true },
               user: null,
               visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -120,7 +118,6 @@ describe("middleware", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: false,
             traits: null,
             user: { key: "random-user-key", name: "joe" },
             visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -156,7 +153,6 @@ describe("middleware", () => {
             endpoint: "https://happykit.dev/api/flags",
             envKey: "flags_pub_000000",
             requestBody: {
-              static: false,
               traits: null,
               user: { key: "random-user-key", name: "joe" },
               visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -202,7 +198,6 @@ describe("middleware", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: false,
             traits: null,
             user: null,
             // nanoid is mocked to return "V1StGXR8_Z5jdHi6B-myT",
@@ -235,7 +230,6 @@ describe("middleware", () => {
             endpoint: "https://happykit.dev/api/flags",
             envKey: "flags_pub_000000",
             requestBody: {
-              static: false,
               traits: null,
               user: null,
               visitorKey: "V1StGXR8_Z5jdHi6B-myT",

--- a/package/src/edge.ts
+++ b/package/src/edge.ts
@@ -114,7 +114,6 @@ export function getEdgeFlags<F extends Flags = Flags>(options: {
       visitorKey,
       user: options.user || null,
       traits: options.traits || null,
-      static: false,
     },
   };
 

--- a/package/src/server.spec.ts
+++ b/package/src/server.spec.ts
@@ -34,7 +34,6 @@ describe("server-side rendering (pure + hybrid)", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: false,
             traits: { teamMember: true },
             user: null,
             visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -70,7 +69,6 @@ describe("server-side rendering (pure + hybrid)", () => {
               endpoint: "https://happykit.dev/api/flags",
               envKey: "flags_pub_000000",
               requestBody: {
-                static: false,
                 traits: { teamMember: true },
                 user: null,
                 visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -102,7 +100,6 @@ describe("server-side rendering (pure + hybrid)", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: false,
             traits: null,
             user: { key: "random-user-key", name: "joe" },
             visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -142,7 +139,6 @@ describe("server-side rendering (pure + hybrid)", () => {
             endpoint: "https://happykit.dev/api/flags",
             envKey: "flags_pub_000000",
             requestBody: {
-              static: false,
               traits: null,
               user: { key: "random-user-key", name: "joe" },
               visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -175,7 +171,6 @@ describe("server-side rendering (pure + hybrid)", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: false,
             traits: null,
             user: null,
             // nanoid is mocked to return "V1StGXR8_Z5jdHi6B-myT",
@@ -212,7 +207,6 @@ describe("server-side rendering (pure + hybrid)", () => {
             endpoint: "https://happykit.dev/api/flags",
             envKey: "flags_pub_000000",
             requestBody: {
-              static: false,
               traits: null,
               user: null,
               visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -242,7 +236,6 @@ describe("server-side rendering (pure + hybrid)", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: false,
             traits: null,
             user: null,
             visitorKey: "V1StGXR8_Z5jdHi6B-myT",
@@ -281,7 +274,6 @@ describe("server-side rendering (pure + hybrid)", () => {
               visitorKey: "V1StGXR8_Z5jdHi6B-myT",
               user: null,
               traits: null,
-              static: false,
             },
           },
           outcome: { error: "request-timed-out" },
@@ -305,7 +297,6 @@ describe("static site generation (pure + hybrid)", () => {
       {
         url: "https://happykit.dev/api/flags/flags_pub_000000",
         body: {
-          static: true,
           traits: null,
           user: null,
           visitorKey: null,
@@ -329,7 +320,6 @@ describe("static site generation (pure + hybrid)", () => {
           endpoint: "https://happykit.dev/api/flags",
           envKey: "flags_pub_000000",
           requestBody: {
-            static: true,
             traits: null,
             user: null,
             visitorKey: null,
@@ -353,7 +343,6 @@ describe("static site generation (pure + hybrid)", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: true,
             traits: { friendly: true },
             user: null,
             visitorKey: null,
@@ -382,7 +371,6 @@ describe("static site generation (pure + hybrid)", () => {
             endpoint: "https://happykit.dev/api/flags",
             envKey: "flags_pub_000000",
             requestBody: {
-              static: true,
               traits: { friendly: true },
               user: null,
               visitorKey: null,
@@ -407,7 +395,6 @@ describe("static site generation (pure + hybrid)", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: true,
             traits: null,
             user: { key: "random-user-key", name: "joe" },
             visitorKey: null,
@@ -436,7 +423,6 @@ describe("static site generation (pure + hybrid)", () => {
             endpoint: "https://happykit.dev/api/flags",
             envKey: "flags_pub_000000",
             requestBody: {
-              static: true,
               traits: null,
               user: { key: "random-user-key", name: "joe" },
               visitorKey: null,
@@ -461,7 +447,6 @@ describe("static site generation (pure + hybrid)", () => {
         {
           url: "https://happykit.dev/api/flags/flags_pub_000000",
           body: {
-            static: true,
             traits: null,
             user: null,
             visitorKey: null,
@@ -486,7 +471,6 @@ describe("static site generation (pure + hybrid)", () => {
             endpoint: "https://happykit.dev/api/flags",
             envKey: "flags_pub_000000",
             requestBody: {
-              static: true,
               visitorKey: null,
               user: null,
               traits: null,

--- a/package/src/server.ts
+++ b/package/src/server.ts
@@ -119,7 +119,6 @@ export function getFlags<F extends Flags = Flags>(options: {
       visitorKey,
       user: options.user || null,
       traits: options.traits || null,
-      static: !has(options.context, "req"),
     },
   };
 

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -67,7 +67,6 @@ export type EvaluationRequestBody = {
   visitorKey: string | null;
   user: FlagUser | null;
   traits: Traits | null;
-  static?: boolean;
 };
 
 export type EvaluationResponseBody<F extends Flags> = {
@@ -207,7 +206,7 @@ export type SucceededFlagBag<F extends Flags> = {
   data: EvaluationResponseBody<F>;
   error: null;
   fetching: false;
-  // true, unless input is for a static page
+  // true, unless input is for a static page (has no visitorKey)
   settled: boolean;
   revalidate: Revalidate;
   visitorKey: string;
@@ -228,7 +227,7 @@ export type FailedFlagBag<F extends Flags> = {
   data: null;
   error: ResolvingError;
   fetching: false;
-  // true, unless input is for a static page
+  // true, unless input is for a static page (has no visitorKey)
   settled: boolean;
   revalidate: Revalidate;
   visitorKey: string;


### PR DESCRIPTION
Context: Feature flags can be evaluated on behalf of a user (server-side rendering) or without the context of a user (usually during static site generation). HappyKit needs a way to distinguish that and was previously sending `static` in the request body. This is no longer necessary as we can simply rely on `visitorKey` instead. `visitorKey` will only be present when evaluating flags on behalf of a user.

Knowing whether flags were evaluated on behalf of a user or without the context of a user allows the `@happykit/flags/client` to decide whether to reevaluate the flags on mount or not (reevaluate if no `visitorKey` was present in the initial response).

---

If `visitorKey` is not present in the request, no `visitorKey` will get generated by HappyKit's API.

The API now purely relies on `visitorKey`, and no longer on `static`. If `visitorKey` is present in the API response, the client will generate a `visitorKey` and reevaluate the flags with that.

`@happykit/flags` should treat all responses without a `visitorKey` as static sites. `@happykit/flags` needs to generate a `visitorKey` in case no `visitorKey` is present and reevaluate flags on behalf of a specific visitor (a non-static site).

All evaluations on behalf of a user (for server-side rendering) generate a `visitorKey` themselves (or use the existing `visitorKey` if present) and invoke the HappyKit API with it. `getFlags` and `getEdgeFlags` do this for you.