### PR TITLE
fix configuration warning

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "@tailwindcss/typography": "0.5.1",
     "@tailwindui/react": "0.1.1",
     "@types/dedent": "0.7.0",
-    "@types/node": "17.0.14",
+    "@types/node": "17.0.15",
     "@types/react": "17.0.39",
     "autoprefixer": "10.4.2",
     "clsx": "1.1.1",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happykit/flags",
-  "version": "2.0.6-rc.0",
+  "version": "2.0.6-rc.1",
   "description": "Feature Flags for Next.js",
   "author": "Dominik Ferber <dominik.ferber+npm@gmail.com> (http://dferber.de/)",
   "license": "MIT",

--- a/package/package.json
+++ b/package/package.json
@@ -53,7 +53,7 @@
     "@types/cookie": "0.4.1",
     "@types/jest": "27.4.0",
     "fetch-mock-jest": "1.5.1",
-    "jest": "27.4.7",
+    "jest": "27.5.0",
     "next": ">=12.0.2",
     "node-fetch": "^2.6.7",
     "ts-jest": "27.1.3",

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happykit/flags",
-  "version": "2.0.5",
+  "version": "2.0.6-rc.0",
   "description": "Feature Flags for Next.js",
   "author": "Dominik Ferber <dominik.ferber+npm@gmail.com> (http://dferber.de/)",
   "license": "MIT",

--- a/package/src/client.ts
+++ b/package/src/client.ts
@@ -1,9 +1,8 @@
 import * as React from "react";
 import { nanoid } from "nanoid";
-import { isConfigured, config, Configuration } from "./config";
+import { Configuration, getConfig } from "./config";
 import {
   InitialFlagState,
-  MissingConfigurationError,
   Flags,
   Input,
   Outcome,
@@ -386,9 +385,8 @@ export type UseFlagsOptions<F extends Flags = Flags> =
 export function useFlags<F extends Flags = Flags>(
   options: UseFlagsOptions<F> = {}
 ): FlagBag<F> {
-  if (!isConfigured(config)) throw new MissingConfigurationError();
   useOnce();
-  const staticConfig = config;
+  const config = getConfig();
 
   const [generatedVisitorKey] = React.useState(nanoid);
 
@@ -411,7 +409,7 @@ export function useFlags<F extends Flags = Flags>(
       if (!initialFlagState?.input) return [{ name: "empty" }, []];
 
       const input = getInput({
-        config: staticConfig,
+        config,
         visitorKeyInState: initialFlagState.input.requestBody.visitorKey,
         generatedVisitorKey,
         user: currentUser,
@@ -448,7 +446,7 @@ export function useFlags<F extends Flags = Flags>(
 
   React.useEffect(() => {
     const input = getInput({
-      config: staticConfig,
+      config,
       visitorKeyInState: state.input?.requestBody.visitorKey,
       generatedVisitorKey,
       user: currentUser,

--- a/package/src/client.ts
+++ b/package/src/client.ts
@@ -18,6 +18,7 @@ import {
   SucceededFlagBag,
   RevalidatingAfterSuccessFlagBag,
   FailedFlagBag,
+  MissingConfigurationError,
 } from "./types";
 import {
   deepEqual,
@@ -385,8 +386,10 @@ export type UseFlagsOptions<F extends Flags = Flags> =
 export function useFlags<F extends Flags = Flags>(
   options: UseFlagsOptions<F> = {}
 ): FlagBag<F> {
-  useOnce();
   const config = getConfig();
+  if (!config) throw new MissingConfigurationError();
+
+  useOnce();
 
   const [generatedVisitorKey] = React.useState(nanoid);
 

--- a/package/src/config.ts
+++ b/package/src/config.ts
@@ -1,8 +1,7 @@
-import {
+import type {
   DefaultConfiguration,
   IncomingConfiguration,
   Flags,
-  MissingConfigurationError,
 } from "./types";
 
 export type Configuration<F extends Flags> = DefaultConfiguration &
@@ -10,8 +9,8 @@ export type Configuration<F extends Flags> = DefaultConfiguration &
 
 let config: Configuration<Flags> | null = null;
 
+// getter is necessary as we can't export a live binding of "config"
 export function getConfig() {
-  if (!config) throw new MissingConfigurationError();
   return config;
 }
 

--- a/package/src/config.ts
+++ b/package/src/config.ts
@@ -1,12 +1,19 @@
-import type {
+import {
   DefaultConfiguration,
   IncomingConfiguration,
   Flags,
+  MissingConfigurationError,
 } from "./types";
 
 export type Configuration<F extends Flags> = DefaultConfiguration &
   IncomingConfiguration<F>;
-export let config: Configuration<Flags> | null = null;
+
+let config: Configuration<Flags> | null = null;
+
+export function getConfig() {
+  if (!config) throw new MissingConfigurationError();
+  return config;
+}
 
 export function _resetConfig() {
   config = null;
@@ -35,10 +42,4 @@ export function configure<F extends Flags = Flags>(
   }
 
   config = Object.assign({}, defaults, options);
-}
-
-export function isConfigured<F extends Flags, C = Configuration<F>>(
-  c: C | null
-): c is C {
-  return c !== null;
 }

--- a/package/src/edge.ts
+++ b/package/src/edge.ts
@@ -1,6 +1,6 @@
 /** global: fetch */
 import type { NextRequest } from "next/server";
-import { config, isConfigured } from "./config";
+import { getConfig } from "./config";
 import type { CookieSerializeOptions } from "cookie";
 import { nanoid } from "nanoid";
 import type {
@@ -93,11 +93,7 @@ export function getEdgeFlags<F extends Flags = Flags>(options: {
   user?: FlagUser;
   traits?: Traits;
 }): Promise<GetFlagsSuccessBag<F> | GetFlagsErrorBag<F>> {
-  if (!isConfigured(config))
-    throw new Error(
-      "@happykit/flags: Missing configuration. Call configure() first."
-    );
-  const staticConfig = config;
+  const config = getConfig();
 
   // determine visitor key
   const visitorKeyFromCookie = options.request.cookies.hkvk || null;
@@ -140,7 +136,7 @@ export function getEdgeFlags<F extends Flags = Flags>(options: {
       | GetFlagsErrorBag<F> => {
       if (!workerResponse.ok /* status not 200-299 */) {
         return {
-          flags: staticConfig.defaultFlags as F,
+          flags: config.defaultFlags as F,
           data: null,
           error: "response-not-ok",
           initialFlagState: { input, outcome: { error: "response-not-ok" } },
@@ -156,7 +152,7 @@ export function getEdgeFlags<F extends Flags = Flags>(options: {
             : null;
           const flagsWithDefaults = combineRawFlagsWithDefaultFlags<F>(
             flags,
-            staticConfig.defaultFlags
+            config.defaultFlags
           );
 
           const cookieOptions: CookieSerializeOptions = {
@@ -182,7 +178,7 @@ export function getEdgeFlags<F extends Flags = Flags>(options: {
         },
         () => {
           return {
-            flags: staticConfig.defaultFlags as F,
+            flags: config.defaultFlags as F,
             data: null,
             error: "invalid-response-body",
             initialFlagState: {
@@ -196,7 +192,7 @@ export function getEdgeFlags<F extends Flags = Flags>(options: {
     },
     () => {
       return {
-        flags: staticConfig.defaultFlags as F,
+        flags: config.defaultFlags as F,
         data: null,
         error: "network-error",
         initialFlagState: { input, outcome: { error: "network-error" } },

--- a/package/src/edge.ts
+++ b/package/src/edge.ts
@@ -94,6 +94,13 @@ export function getEdgeFlags<F extends Flags = Flags>(options: {
   traits?: Traits;
 }): Promise<GetFlagsSuccessBag<F> | GetFlagsErrorBag<F>> {
   const config = getConfig();
+  if (!config) {
+    // can't throw MissingConfigurationError here as it would lead to Next.js'
+    // "Dynamic Code Evaluation (e. g. 'eval', 'new Function') not allowed" error
+    throw new Error(
+      "@happykit/flags: Missing configuration. Call configure() first."
+    );
+  }
 
   // determine visitor key
   const visitorKeyFromCookie = options.request.cookies.hkvk || null;

--- a/package/src/server.ts
+++ b/package/src/server.ts
@@ -8,7 +8,7 @@ import type {
 } from "next";
 import { getConfig } from "./config";
 import { nanoid } from "nanoid";
-import {
+import type {
   FlagUser,
   Traits,
   Flags,
@@ -18,6 +18,7 @@ import {
   ResolvingError,
   Input,
 } from "./types";
+import { MissingConfigurationError } from "./types";
 import {
   has,
   serializeVisitorKeyCookie,
@@ -87,6 +88,7 @@ export function getFlags<F extends Flags = Flags>(options: {
   staticLoadingTimeout?: number | false;
 }): Promise<GetFlagsSuccessBag<F> | GetFlagsErrorBag<F>> {
   const config = getConfig();
+  if (!config) throw new MissingConfigurationError();
 
   const currentStaticLoadingTimeout = has(options, "staticLoadingTimeout")
     ? options.staticLoadingTimeout

--- a/package/src/server.ts
+++ b/package/src/server.ts
@@ -6,12 +6,11 @@ import type {
   GetStaticPathsContext,
   GetStaticPropsContext,
 } from "next";
-import { config, isConfigured } from "./config";
+import { getConfig } from "./config";
 import { nanoid } from "nanoid";
 import {
   FlagUser,
   Traits,
-  MissingConfigurationError,
   Flags,
   SuccessInitialFlagState,
   ErrorInitialFlagState,
@@ -87,8 +86,7 @@ export function getFlags<F extends Flags = Flags>(options: {
   serverLoadingTimeout?: number | false;
   staticLoadingTimeout?: number | false;
 }): Promise<GetFlagsSuccessBag<F> | GetFlagsErrorBag<F>> {
-  if (!isConfigured(config)) throw new MissingConfigurationError();
-  const staticConfig = config;
+  const config = getConfig();
 
   const currentStaticLoadingTimeout = has(options, "staticLoadingTimeout")
     ? options.staticLoadingTimeout
@@ -163,7 +161,7 @@ export function getFlags<F extends Flags = Flags>(options: {
 
       if (!workerResponse.ok /* status not 200-299 */) {
         return {
-          flags: staticConfig.defaultFlags as F,
+          flags: config.defaultFlags as F,
           data: null,
           error: "response-not-ok",
           initialFlagState: { input, outcome: { error: "response-not-ok" } },
@@ -186,7 +184,7 @@ export function getFlags<F extends Flags = Flags>(options: {
             : null;
           const flagsWithDefaults = combineRawFlagsWithDefaultFlags<F>(
             flags,
-            staticConfig.defaultFlags
+            config.defaultFlags
           );
 
           return {
@@ -198,7 +196,7 @@ export function getFlags<F extends Flags = Flags>(options: {
         },
         () => {
           return {
-            flags: staticConfig.defaultFlags as F,
+            flags: config.defaultFlags as F,
             data: null,
             error: "invalid-response-body",
             initialFlagState: {
@@ -214,7 +212,7 @@ export function getFlags<F extends Flags = Flags>(options: {
 
       return error?.name === "AbortError"
         ? {
-            flags: staticConfig.defaultFlags as F,
+            flags: config.defaultFlags as F,
             data: null,
             error: "request-timed-out",
             initialFlagState: {
@@ -223,7 +221,7 @@ export function getFlags<F extends Flags = Flags>(options: {
             },
           }
         : {
-            flags: staticConfig.defaultFlags as F,
+            flags: config.defaultFlags as F,
             data: null,
             error: "network-error",
             initialFlagState: { input, outcome: { error: "network-error" } },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,158 +1592,158 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jest/console@^27.4.6":
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.4.6.tgz#0742e6787f682b22bdad56f9db2a8a77f6a86107"
-  integrity sha512-jauXyacQD33n47A44KrlOVeiXHEXDqapSdfb9kTekOchH/Pd18kBIO1+xxJQRLuG+LUuljFCwTG92ra4NW7SpA==
+"@jest/console@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.5.0.tgz#82289a589ad5803555b50b64178128b7a8e45282"
+  integrity sha512-WUzX5neFb0IOQOy/7A2VhiGdxJKk85Xns2Oq29JaHmtnSel+BsjwyQZxzAs2Xxfd2i452fwdDG9ox/IWi81bdQ==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
     chalk "^4.0.0"
-    jest-message-util "^27.4.6"
-    jest-util "^27.4.2"
+    jest-message-util "^27.5.0"
+    jest-util "^27.5.0"
     slash "^3.0.0"
 
-"@jest/core@^27.4.7":
-  version "27.4.7"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.4.7.tgz#84eabdf42a25f1fa138272ed229bcf0a1b5e6913"
-  integrity sha512-n181PurSJkVMS+kClIFSX/LLvw9ExSb+4IMtD6YnfxZVerw9ANYtW0bPrm0MJu2pfe9SY9FJ9FtQ+MdZkrZwjg==
+"@jest/core@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.5.0.tgz#27b383f497ff1671cc30fd5e22eba9d9b10c3031"
+  integrity sha512-DcUTkZyon+dRozTEjy38Bgt3PIU51GdUJuz3uHKg5maGtmCaYqPUGiM3Xddqi7eIMC7E3fTGIlHqH9i0pTOy6Q==
   dependencies:
-    "@jest/console" "^27.4.6"
-    "@jest/reporters" "^27.4.6"
-    "@jest/test-result" "^27.4.6"
-    "@jest/transform" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/console" "^27.5.0"
+    "@jest/reporters" "^27.5.0"
+    "@jest/test-result" "^27.5.0"
+    "@jest/transform" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     emittery "^0.8.1"
     exit "^0.1.2"
-    graceful-fs "^4.2.4"
-    jest-changed-files "^27.4.2"
-    jest-config "^27.4.7"
-    jest-haste-map "^27.4.6"
-    jest-message-util "^27.4.6"
-    jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.6"
-    jest-resolve-dependencies "^27.4.6"
-    jest-runner "^27.4.6"
-    jest-runtime "^27.4.6"
-    jest-snapshot "^27.4.6"
-    jest-util "^27.4.2"
-    jest-validate "^27.4.6"
-    jest-watcher "^27.4.6"
+    graceful-fs "^4.2.9"
+    jest-changed-files "^27.5.0"
+    jest-config "^27.5.0"
+    jest-haste-map "^27.5.0"
+    jest-message-util "^27.5.0"
+    jest-regex-util "^27.5.0"
+    jest-resolve "^27.5.0"
+    jest-resolve-dependencies "^27.5.0"
+    jest-runner "^27.5.0"
+    jest-runtime "^27.5.0"
+    jest-snapshot "^27.5.0"
+    jest-util "^27.5.0"
+    jest-validate "^27.5.0"
+    jest-watcher "^27.5.0"
     micromatch "^4.0.4"
     rimraf "^3.0.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^27.4.6":
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.4.6.tgz#1e92885d64f48c8454df35ed9779fbcf31c56d8b"
-  integrity sha512-E6t+RXPfATEEGVidr84WngLNWZ8ffCPky8RqqRK6u1Bn0LK92INe0MDttyPl/JOzaq92BmDzOeuqk09TvM22Sg==
+"@jest/environment@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.5.0.tgz#a473bc76261aad7dfa3a1d8e35155953a5ba3436"
+  integrity sha512-lg0JFsMaLKgpwzs0knOg21Z4OQwaJoBLutnmYzip4tyLTXP21VYWtYGpLXgx42fw/Mw05m1WDXWKgwR6WnsiTw==
   dependencies:
-    "@jest/fake-timers" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/fake-timers" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
-    jest-mock "^27.4.6"
+    jest-mock "^27.5.0"
 
-"@jest/fake-timers@^27.4.6":
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.4.6.tgz#e026ae1671316dbd04a56945be2fa251204324e8"
-  integrity sha512-mfaethuYF8scV8ntPpiVGIHQgS0XIALbpY2jt2l7wb/bvq4Q5pDLk4EP4D7SAvYT1QrPOPVZAtbdGAOOyIgs7A==
+"@jest/fake-timers@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.5.0.tgz#f9e07b4c723a535f7c532cfb403394fa40d88c8a"
+  integrity sha512-e3WrlpqSHq3HAQ03JFjTn8YCrsyg640/sr1rjkM2rNv8z1ufjudpv4xq6DvvTJYB6FuUrfg0g+7bSKPet5QfCQ==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     "@sinonjs/fake-timers" "^8.0.1"
     "@types/node" "*"
-    jest-message-util "^27.4.6"
-    jest-mock "^27.4.6"
-    jest-util "^27.4.2"
+    jest-message-util "^27.5.0"
+    jest-mock "^27.5.0"
+    jest-util "^27.5.0"
 
-"@jest/globals@^27.4.6":
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.4.6.tgz#3f09bed64b0fd7f5f996920258bd4be8f52f060a"
-  integrity sha512-kAiwMGZ7UxrgPzu8Yv9uvWmXXxsy0GciNejlHvfPIfWkSxChzv6bgTS3YqBkGuHcis+ouMFI2696n2t+XYIeFw==
+"@jest/globals@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.5.0.tgz#16271323f79e3b0fe0842e9588241d202a6c2aff"
+  integrity sha512-wWpMnTiR65Q4JD7fr2BqN+ZDbi99mmILnEM6u7AaX4geASEIVvQsiB4RCvwZrIX5YZCsAjviJQVq9CYddLABkg==
   dependencies:
-    "@jest/environment" "^27.4.6"
-    "@jest/types" "^27.4.2"
-    expect "^27.4.6"
+    "@jest/environment" "^27.5.0"
+    "@jest/types" "^27.5.0"
+    expect "^27.5.0"
 
-"@jest/reporters@^27.4.6":
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.4.6.tgz#b53dec3a93baf9b00826abf95b932de919d6d8dd"
-  integrity sha512-+Zo9gV81R14+PSq4wzee4GC2mhAN9i9a7qgJWL90Gpx7fHYkWpTBvwWNZUXvJByYR9tAVBdc8VxDWqfJyIUrIQ==
+"@jest/reporters@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.5.0.tgz#e7602e12656b5051bf4e784cbdd82d4ec1299e33"
+  integrity sha512-DG+BmVSx2uaJSTKz5z1eScgHTQ6/cZ5CCKSpmpr4sXQPwV2V5aUMOBDwXX1MnqNRhH7/Rq9K97ynnocvho5aMA==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^27.4.6"
-    "@jest/test-result" "^27.4.6"
-    "@jest/transform" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/console" "^27.5.0"
+    "@jest/test-result" "^27.5.0"
+    "@jest/transform" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
     glob "^7.1.2"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     istanbul-lib-coverage "^3.0.0"
     istanbul-lib-instrument "^5.1.0"
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
     istanbul-reports "^3.1.3"
-    jest-haste-map "^27.4.6"
-    jest-resolve "^27.4.6"
-    jest-util "^27.4.2"
-    jest-worker "^27.4.6"
+    jest-haste-map "^27.5.0"
+    jest-resolve "^27.5.0"
+    jest-util "^27.5.0"
+    jest-worker "^27.5.0"
     slash "^3.0.0"
     source-map "^0.6.0"
     string-length "^4.0.1"
     terminal-link "^2.0.0"
     v8-to-istanbul "^8.1.0"
 
-"@jest/source-map@^27.4.0":
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.4.0.tgz#2f0385d0d884fb3e2554e8f71f8fa957af9a74b6"
-  integrity sha512-Ntjx9jzP26Bvhbm93z/AKcPRj/9wrkI88/gK60glXDx1q+IeI0rf7Lw2c89Ch6ofonB0On/iRDreQuQ6te9pgQ==
+"@jest/source-map@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.5.0.tgz#f22a7e759b8807491f84719c01acf433b917c7a0"
+  integrity sha512-0xr7VZ+JNCRrlCyRMYhquUm8eU3kNdGDaIW4s3L625bNjk273v9ZhAm3YczIuzJzYH0pnjT+QSCiZQegWKjeow==
   dependencies:
     callsites "^3.0.0"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     source-map "^0.6.0"
 
-"@jest/test-result@^27.4.6":
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.4.6.tgz#b3df94c3d899c040f602cea296979844f61bdf69"
-  integrity sha512-fi9IGj3fkOrlMmhQqa/t9xum8jaJOOAi/lZlm6JXSc55rJMXKHxNDN1oCP39B0/DhNOa2OMupF9BcKZnNtXMOQ==
+"@jest/test-result@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.5.0.tgz#29e0ace33570c9dcbd47c67e954f77a7d7fff98e"
+  integrity sha512-Lxecvx5mN6WIeynIyW0dWDQm8UPGMHvTwxUPK+OsZaqBDMGaNDSZtw53VoVk7HyT6AcRblMR/pfa0XucmH4hGw==
   dependencies:
-    "@jest/console" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/console" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^27.4.6":
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.4.6.tgz#447339b8a3d7b5436f50934df30854e442a9d904"
-  integrity sha512-3GL+nsf6E1PsyNsJuvPyIz+DwFuCtBdtvPpm/LMXVkBJbdFvQYCDpccYT56qq5BGniXWlE81n2qk1sdXfZebnw==
+"@jest/test-sequencer@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.5.0.tgz#68beceb3de818dcb34fb3ea59be3c22c890bb6e5"
+  integrity sha512-WzjcDflqbpWe+SnJPCvB2gB6haGfrkzAgzY6Pb1aq+EPoVAj2mwBaKN0ROWI4H87aSslCjq2M+BUQFNJ8VpnDA==
   dependencies:
-    "@jest/test-result" "^27.4.6"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.6"
-    jest-runtime "^27.4.6"
+    "@jest/test-result" "^27.5.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^27.5.0"
+    jest-runtime "^27.5.0"
 
-"@jest/transform@^27.4.6":
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.4.6.tgz#153621940b1ed500305eacdb31105d415dc30231"
-  integrity sha512-9MsufmJC8t5JTpWEQJ0OcOOAXaH5ioaIX6uHVBLBMoCZPfKKQF+EqP8kACAvCZ0Y1h2Zr3uOccg8re+Dr5jxyw==
+"@jest/transform@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.5.0.tgz#a4941e69ac51e8aa9a255ff4855b564c228c400b"
+  integrity sha512-yXUy/iO3TH1itxJ9BF7LLjuXt8TtgtjAl0PBQbUaCvRa+L0yYBob6uayW9dFRX/CDQweouLhvmXh44zRiaB+yA==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.6"
-    jest-regex-util "^27.4.0"
-    jest-util "^27.4.2"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^27.5.0"
+    jest-regex-util "^27.5.0"
+    jest-util "^27.5.0"
     micromatch "^4.0.4"
     pirates "^4.0.4"
     slash "^3.0.0"
@@ -1787,6 +1787,17 @@
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
   integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.5.0":
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.5.0.tgz#6ad04a5c5355fd9f46e5cf761850e0edb3c209dd"
+  integrity sha512-oDHEp7gwSgA82RZ6pzUL3ugM2njP/lVB1MsxRZNOBk+CoNvh9SpH1lQixPFc/kDlV50v59csiW4HLixWmhmgPQ==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -2209,10 +2220,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
   integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
 
-"@types/node@17.0.14":
-  version "17.0.14"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.14.tgz#33b9b94f789a8fedd30a68efdbca4dbb06b61f20"
-  integrity sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==
+"@types/node@17.0.15":
+  version "17.0.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.15.tgz#97779282c09c09577120a2162e71d8380003590a"
+  integrity sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2461,18 +2472,18 @@ autoprefixer@10.4.2:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
-babel-jest@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.6.tgz#4d024e69e241cdf4f396e453a07100f44f7ce314"
-  integrity sha512-qZL0JT0HS1L+lOuH+xC2DVASR3nunZi/ozGhpgauJHgmI7f8rudxf6hUjEHympdQ/J64CdKmPkgfJ+A3U6QCrg==
+babel-jest@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.5.0.tgz#c653985241af3c76f59d70d65a570860c2594a50"
+  integrity sha512-puhCyvBTNLevhbd1oyw6t3gWBicWoUARQYKCBB/B1moif17NbyhxbsfadqZIw8zfJJD+W7Vw0Nb20pEjLxkXqQ==
   dependencies:
-    "@jest/transform" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/transform" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.1.1"
-    babel-preset-jest "^27.4.0"
+    babel-preset-jest "^27.5.0"
     chalk "^4.0.0"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     slash "^3.0.0"
 
 babel-plugin-dynamic-import-node@^2.3.3:
@@ -2493,10 +2504,10 @@ babel-plugin-istanbul@^6.1.1:
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.4.0.tgz#d7831fc0f93573788d80dee7e682482da4c730d6"
-  integrity sha512-Jcu7qS4OX5kTWBc45Hz7BMmgXuJqRnhatqpUhnzGC3OBYpOmf2tv6jFNwZpwM7wU7MUuv2r9IPS/ZlYOuburVw==
+babel-plugin-jest-hoist@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.5.0.tgz#8fdf07835f2165a068de3ce95fd7749a89801b51"
+  integrity sha512-ztwNkHl+g1GaoQcb8f2BER4C3LMvSXuF7KVqtUioXQgScSEnkl6lLgCILUYIR+CPTwL8H3F/PNLze64HPWF9JA==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
@@ -2545,12 +2556,12 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
 
-babel-preset-jest@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-27.4.0.tgz#70d0e676a282ccb200fbabd7f415db5fdf393bca"
-  integrity sha512-NK4jGYpnBvNxcGo7/ZpZJr51jCGT+3bwwpVIDY2oNfTxJJldRtB4VAcYdgp1loDE50ODuTu+yBjpMAswv5tlpg==
+babel-preset-jest@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-27.5.0.tgz#4e308711c3d2ff1f45cf5d9a23646e37b621fc9f"
+  integrity sha512-7bfu1cJBlgK/nKfTvMlElzA3jpi6GzDWX3fntnyP2cQSzoi/KUz6ewGlcb3PSRYZGyv+uPnVHY0Im3JbsViqgA==
   dependencies:
-    babel-plugin-jest-hoist "^27.4.0"
+    babel-plugin-jest-hoist "^27.5.0"
     babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
@@ -3017,10 +3028,10 @@ diff-sequences@^27.0.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
-diff-sequences@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
-  integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
+diff-sequences@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.0.tgz#a8ac0cb742b17d6f30a6c43e233893a2402c0729"
+  integrity sha512-ZsOBWnhXiH+Zn0DcBNX/tiQsqrREHs/6oQsEVy2VJJjrTblykPima11pyHMSA/7PGmD+fwclTnKVKL/qtNREDQ==
 
 dlv@^1.1.3:
   version "1.1.3"
@@ -3150,15 +3161,15 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
-expect@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-27.4.6.tgz#f335e128b0335b6ceb4fcab67ece7cbd14c942e6"
-  integrity sha512-1M/0kAALIaj5LaG66sFJTbRsWTADnylly82cu4bspI0nl+pgP4E6Bh/aqdHlTUjul06K7xQnnrAoqfxVU0+/ag==
+expect@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-27.5.0.tgz#ea2fbebb483c274043098c34a53923a0aee493f0"
+  integrity sha512-z73GZ132cBqrapO0X6BeRjyBXqOt9YeRtnDteHJIQqp5s2pZ41Hz23VUbsVFMfkrsFLU9GwoIRS0ZzLuFK8M5w==
   dependencies:
-    "@jest/types" "^27.4.2"
-    jest-get-type "^27.4.0"
-    jest-matcher-utils "^27.4.6"
-    jest-message-util "^27.4.6"
+    "@jest/types" "^27.5.0"
+    jest-get-type "^27.5.0"
+    jest-matcher-utils "^27.5.0"
+    jest-message-util "^27.5.0"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -3373,6 +3384,11 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -3687,84 +3703,84 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-changed-files@^27.4.2:
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.4.2.tgz#da2547ea47c6e6a5f6ed336151bd2075736eb4a5"
-  integrity sha512-/9x8MjekuzUQoPjDHbBiXbNEBauhrPU2ct7m8TfCg69ywt1y/N+yYwGh3gCpnqUS3klYWDU/lSNgv+JhoD2k1A==
+jest-changed-files@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.5.0.tgz#61e8d0a7394c1ee1cec4c2893e206e62b1566066"
+  integrity sha512-BGWKI7E6ORqbF5usF1oA4ftbkhVZVrXr8jB0/BrU6TAn3kfOVwX2Zx6pKIXYutJ+qNEjT8Da/gGak0ajya/StA==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     execa "^5.0.0"
     throat "^6.0.1"
 
-jest-circus@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.4.6.tgz#d3af34c0eb742a967b1919fbb351430727bcea6c"
-  integrity sha512-UA7AI5HZrW4wRM72Ro80uRR2Fg+7nR0GESbSI/2M+ambbzVuA63mn5T1p3Z/wlhntzGpIG1xx78GP2YIkf6PhQ==
+jest-circus@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.5.0.tgz#fcff8829ceb2c8ef4b4532ace7734d156c6664b9"
+  integrity sha512-+NPd1OxpAHYKjbW8dgL0huFgmtZRKSUKee/UtRgZJEfAxCeA12d7sp0coh5EGDBpW4fCk1Pcia/2dG+j6BQvdw==
   dependencies:
-    "@jest/environment" "^27.4.6"
-    "@jest/test-result" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/environment" "^27.5.0"
+    "@jest/test-result" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
     dedent "^0.7.0"
-    expect "^27.4.6"
+    expect "^27.5.0"
     is-generator-fn "^2.0.0"
-    jest-each "^27.4.6"
-    jest-matcher-utils "^27.4.6"
-    jest-message-util "^27.4.6"
-    jest-runtime "^27.4.6"
-    jest-snapshot "^27.4.6"
-    jest-util "^27.4.2"
-    pretty-format "^27.4.6"
+    jest-each "^27.5.0"
+    jest-matcher-utils "^27.5.0"
+    jest-message-util "^27.5.0"
+    jest-runtime "^27.5.0"
+    jest-snapshot "^27.5.0"
+    jest-util "^27.5.0"
+    pretty-format "^27.5.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
-jest-cli@^27.4.7:
-  version "27.4.7"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.4.7.tgz#d00e759e55d77b3bcfea0715f527c394ca314e5a"
-  integrity sha512-zREYhvjjqe1KsGV15mdnxjThKNDgza1fhDT+iUsXWLCq3sxe9w5xnvyctcYVT5PcdLSjv7Y5dCwTS3FCF1tiuw==
+jest-cli@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.5.0.tgz#06557ad22818740fb28481089a574ba107a8b369"
+  integrity sha512-9ANs79Goz1ULKtG7HDm/F//4E69v8EFOLXRIHmeC/eK1xTUeQGlU6XP0Zwst386sKaKB4O60qhWY/UaTBS2MLA==
   dependencies:
-    "@jest/core" "^27.4.7"
-    "@jest/test-result" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/core" "^27.5.0"
+    "@jest/test-result" "^27.5.0"
+    "@jest/types" "^27.5.0"
     chalk "^4.0.0"
     exit "^0.1.2"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     import-local "^3.0.2"
-    jest-config "^27.4.7"
-    jest-util "^27.4.2"
-    jest-validate "^27.4.6"
+    jest-config "^27.5.0"
+    jest-util "^27.5.0"
+    jest-validate "^27.5.0"
     prompts "^2.0.1"
     yargs "^16.2.0"
 
-jest-config@^27.4.7:
-  version "27.4.7"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.4.7.tgz#4f084b2acbd172c8b43aa4cdffe75d89378d3972"
-  integrity sha512-xz/o/KJJEedHMrIY9v2ParIoYSrSVY6IVeE4z5Z3i101GoA5XgfbJz+1C8EYPsv7u7f39dS8F9v46BHDhn0vlw==
+jest-config@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.5.0.tgz#d96ccf8e26d3f2f3ae6543686c48449c201bb621"
+  integrity sha512-eOIpvpXFz5WHuIYZN1QmvBLEjsSk3w+IAC/2jBpZClbprF53Bj9meBMgAbE15DSkaaJBDFmhXXd1L2eCLaWxQw==
   dependencies:
     "@babel/core" "^7.8.0"
-    "@jest/test-sequencer" "^27.4.6"
-    "@jest/types" "^27.4.2"
-    babel-jest "^27.4.6"
+    "@jest/test-sequencer" "^27.5.0"
+    "@jest/types" "^27.5.0"
+    babel-jest "^27.5.0"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     deepmerge "^4.2.2"
     glob "^7.1.1"
-    graceful-fs "^4.2.4"
-    jest-circus "^27.4.6"
-    jest-environment-jsdom "^27.4.6"
-    jest-environment-node "^27.4.6"
-    jest-get-type "^27.4.0"
-    jest-jasmine2 "^27.4.6"
-    jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.6"
-    jest-runner "^27.4.6"
-    jest-util "^27.4.2"
-    jest-validate "^27.4.6"
+    graceful-fs "^4.2.9"
+    jest-circus "^27.5.0"
+    jest-environment-jsdom "^27.5.0"
+    jest-environment-node "^27.5.0"
+    jest-get-type "^27.5.0"
+    jest-jasmine2 "^27.5.0"
+    jest-regex-util "^27.5.0"
+    jest-resolve "^27.5.0"
+    jest-runner "^27.5.0"
+    jest-util "^27.5.0"
+    jest-validate "^27.5.0"
     micromatch "^4.0.4"
-    pretty-format "^27.4.6"
+    pretty-format "^27.5.0"
     slash "^3.0.0"
 
 jest-diff@^26.0.0:
@@ -3787,58 +3803,58 @@ jest-diff@^27.0.0:
     jest-get-type "^27.0.6"
     pretty-format "^27.2.4"
 
-jest-diff@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.6.tgz#93815774d2012a2cbb6cf23f84d48c7a2618f98d"
-  integrity sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==
+jest-diff@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.0.tgz#34dc608a3b9159df178dd480b6d835b5e6b92082"
+  integrity sha512-zztvHDCq/QcAVv+o6rts0reupSOxyrX+KLQEOMWCW2trZgcBFgp/oTK7hJCGpXvEIqKrQzyQlaPKn9W04+IMQg==
   dependencies:
     chalk "^4.0.0"
-    diff-sequences "^27.4.0"
-    jest-get-type "^27.4.0"
-    pretty-format "^27.4.6"
+    diff-sequences "^27.5.0"
+    jest-get-type "^27.5.0"
+    pretty-format "^27.5.0"
 
-jest-docblock@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.4.0.tgz#06c78035ca93cbbb84faf8fce64deae79a59f69f"
-  integrity sha512-7TBazUdCKGV7svZ+gh7C8esAnweJoG+SvcF6Cjqj4l17zA2q1cMwx2JObSioubk317H+cjcHgP+7fTs60paulg==
+jest-docblock@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.5.0.tgz#096fa3a8b55d019a954ef7cc205c791bf94b2352"
+  integrity sha512-U4MtJgdZn2x+jpPzd7NAYvDmgJAA5h9QxVAwsyuH7IymGzY8VGHhAkHcIGOmtmdC61ORLxCbEhj6fCJsaCWzXA==
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.4.6.tgz#e7e8561be61d8cc6dbf04296688747ab186c40ff"
-  integrity sha512-n6QDq8y2Hsmn22tRkgAk+z6MCX7MeVlAzxmZDshfS2jLcaBlyhpF3tZSJLR+kXmh23GEvS0ojMR8i6ZeRvpQcA==
+jest-each@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.5.0.tgz#7bd00a767df0fbec0caba3df0d2c0b3268a2ce84"
+  integrity sha512-2vpajSdDMZmAxjSP1f4BG9KKduwHtuaI0w66oqLUkfaGUU7Ix/W+d8BW0h3/QEJiew7hR0GSblqdFwTEEbhBdw==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     chalk "^4.0.0"
-    jest-get-type "^27.4.0"
-    jest-util "^27.4.2"
-    pretty-format "^27.4.6"
+    jest-get-type "^27.5.0"
+    jest-util "^27.5.0"
+    pretty-format "^27.5.0"
 
-jest-environment-jsdom@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.4.6.tgz#c23a394eb445b33621dfae9c09e4c8021dea7b36"
-  integrity sha512-o3dx5p/kHPbUlRvSNjypEcEtgs6LmvESMzgRFQE6c+Prwl2JLA4RZ7qAnxc5VM8kutsGRTB15jXeeSbJsKN9iA==
+jest-environment-jsdom@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.5.0.tgz#6d22d9b76890e9b82c7e1062a15730efb3fb7361"
+  integrity sha512-sX49N8rjp6HSHeGpNgLk6mtHRd1IPAnE/u7wLQkb6Tz/1E08Q++Y8Zk/IbpVdcFywbzH1icFqEuDuHJ6o+uXXg==
   dependencies:
-    "@jest/environment" "^27.4.6"
-    "@jest/fake-timers" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/environment" "^27.5.0"
+    "@jest/fake-timers" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
-    jest-mock "^27.4.6"
-    jest-util "^27.4.2"
+    jest-mock "^27.5.0"
+    jest-util "^27.5.0"
     jsdom "^16.6.0"
 
-jest-environment-node@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.4.6.tgz#ee8cd4ef458a0ef09d087c8cd52ca5856df90242"
-  integrity sha512-yfHlZ9m+kzTKZV0hVfhVu6GuDxKAYeFHrfulmy7Jxwsq4V7+ZK7f+c0XP/tbVDMQW7E4neG2u147hFkuVz0MlQ==
+jest-environment-node@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.5.0.tgz#1ab357b4715bff88d48c8b62b8379002ff955dd1"
+  integrity sha512-7UzisMMfGyrURhS/eUa7p7mgaqN3ajHylsjOgfcn0caNeYRZq4LHKZLfAxrPM34DWLnBZcRupEJlpQsizdSUsw==
   dependencies:
-    "@jest/environment" "^27.4.6"
-    "@jest/fake-timers" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/environment" "^27.5.0"
+    "@jest/fake-timers" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
-    jest-mock "^27.4.6"
-    jest-util "^27.4.2"
+    jest-mock "^27.5.0"
+    jest-util "^27.5.0"
 
 jest-get-type@^26.3.0:
   version "26.3.0"
@@ -3850,93 +3866,93 @@ jest-get-type@^27.0.6:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.6.tgz#0eb5c7f755854279ce9b68a9f1a4122f69047cfe"
   integrity sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
 
-jest-get-type@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5"
-  integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
+jest-get-type@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.0.tgz#861c24aa1b176be83c902292cb9618d580cac8a7"
+  integrity sha512-Vp6O8a52M/dahXRG/E0EJuWQROps2mDQ0sJYPgO8HskhdLwj9ajgngy2OAqZgV6e/RcU67WUHq6TgfvJb8flbA==
 
-jest-haste-map@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.4.6.tgz#c60b5233a34ca0520f325b7e2cc0a0140ad0862a"
-  integrity sha512-0tNpgxg7BKurZeFkIOvGCkbmOHbLFf4LUQOxrQSMjvrQaQe3l6E8x6jYC1NuWkGo5WDdbr8FEzUxV2+LWNawKQ==
+jest-haste-map@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.5.0.tgz#7cc3a920caf304c89fbfceb5d5717b929873f175"
+  integrity sha512-0KfckSBEKV+D6e0toXmIj4zzp72EiBnvkC0L+xYxenkLhAdkp2/8tye4AgMzz7Fqb1r8SWtz7+s1UQLrxMBang==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     "@types/graceful-fs" "^4.1.2"
     "@types/node" "*"
     anymatch "^3.0.3"
     fb-watchman "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-regex-util "^27.4.0"
-    jest-serializer "^27.4.0"
-    jest-util "^27.4.2"
-    jest-worker "^27.4.6"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^27.5.0"
+    jest-serializer "^27.5.0"
+    jest-util "^27.5.0"
+    jest-worker "^27.5.0"
     micromatch "^4.0.4"
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-jasmine2@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.4.6.tgz#109e8bc036cb455950ae28a018f983f2abe50127"
-  integrity sha512-uAGNXF644I/whzhsf7/qf74gqy9OuhvJ0XYp8SDecX2ooGeaPnmJMjXjKt0mqh1Rl5dtRGxJgNrHlBQIBfS5Nw==
+jest-jasmine2@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.5.0.tgz#589d6574d1318d3fb41b3fc368344117ec417dcc"
+  integrity sha512-X7sT3HLNjjrBEepilxzPyNhNdyunaFBepo1L3T/fvYb9tb8Wb8qY576gwIa+SZcqYUqAA7/bT3EpZI4lAp0Qew==
   dependencies:
-    "@jest/environment" "^27.4.6"
-    "@jest/source-map" "^27.4.0"
-    "@jest/test-result" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/environment" "^27.5.0"
+    "@jest/source-map" "^27.5.0"
+    "@jest/test-result" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
-    expect "^27.4.6"
+    expect "^27.5.0"
     is-generator-fn "^2.0.0"
-    jest-each "^27.4.6"
-    jest-matcher-utils "^27.4.6"
-    jest-message-util "^27.4.6"
-    jest-runtime "^27.4.6"
-    jest-snapshot "^27.4.6"
-    jest-util "^27.4.2"
-    pretty-format "^27.4.6"
+    jest-each "^27.5.0"
+    jest-matcher-utils "^27.5.0"
+    jest-message-util "^27.5.0"
+    jest-runtime "^27.5.0"
+    jest-snapshot "^27.5.0"
+    jest-util "^27.5.0"
+    pretty-format "^27.5.0"
     throat "^6.0.1"
 
-jest-leak-detector@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.4.6.tgz#ed9bc3ce514b4c582637088d9faf58a33bd59bf4"
-  integrity sha512-kkaGixDf9R7CjHm2pOzfTxZTQQQ2gHTIWKY/JZSiYTc90bZp8kSZnUMS3uLAfwTZwc0tcMRoEX74e14LG1WapA==
+jest-leak-detector@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.5.0.tgz#c98c02e64eab4da9a8b91f058d2b7473272272ee"
+  integrity sha512-Ak3k+DD3ao5d4/zzJrxAQ5UV5wiCrp47jH94ZD4/vXSzQgE6WBVDfg83VtculLILO7Y6/Q/7yzKSrtN9Na8luA==
   dependencies:
-    jest-get-type "^27.4.0"
-    pretty-format "^27.4.6"
+    jest-get-type "^27.5.0"
+    pretty-format "^27.5.0"
 
-jest-matcher-utils@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.4.6.tgz#53ca7f7b58170638590e946f5363b988775509b8"
-  integrity sha512-XD4PKT3Wn1LQnRAq7ZsTI0VRuEc9OrCPFiO1XL7bftTGmfNF0DcEwMHRgqiu7NGf8ZoZDREpGrCniDkjt79WbA==
+jest-matcher-utils@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.0.tgz#d2fc737224fb3bfa38eaa2393ac5bc953d5c5697"
+  integrity sha512-5ruyzWMGb1ilCWD6ECwNdOhQBeIXAjHmHd5c3uO6quR7RIMHPRP2ucOaejz2j+0R0Ko4GanWM6SqXAeF8nYN5g==
   dependencies:
     chalk "^4.0.0"
-    jest-diff "^27.4.6"
-    jest-get-type "^27.4.0"
-    pretty-format "^27.4.6"
+    jest-diff "^27.5.0"
+    jest-get-type "^27.5.0"
+    pretty-format "^27.5.0"
 
-jest-message-util@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.4.6.tgz#9fdde41a33820ded3127465e1a5896061524da31"
-  integrity sha512-0p5szriFU0U74czRSFjH6RyS7UYIAkn/ntwMuOwTGWrQIOh5NzXXrq72LOqIkJKKvFbPq+byZKuBz78fjBERBA==
+jest-message-util@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.5.0.tgz#654a781b38a305b1fd8120053c784c67bca00a52"
+  integrity sha512-lfbWRhTtmZMEHPAtl0SrvNzK1F4UnVNMHOliRQT2BJ4sBFzIb0gBCHA4ebWD4o6l1fUyvDPxM01K9OIMQTAdQw==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     "@types/stack-utils" "^2.0.0"
     chalk "^4.0.0"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     micromatch "^4.0.4"
-    pretty-format "^27.4.6"
+    pretty-format "^27.5.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.4.6.tgz#77d1ba87fbd33ccb8ef1f061697e7341b7635195"
-  integrity sha512-kvojdYRkst8iVSZ1EJ+vc1RRD9llueBjKzXzeCytH3dMM7zvPV/ULcfI2nr0v0VUgm3Bjt3hBCQvOeaBz+ZTHw==
+jest-mock@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.5.0.tgz#1018656fe6bcd0f58fd1edca7f420169f6707c6e"
+  integrity sha512-PHluG6MJGng82/sxh8OiB9fnxzNn3cazceSHCAmAKs4g5rMhc3EZCrJXv+4w61rA2WGagMUj7QLLrA1SRlFpzQ==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.2:
@@ -3944,126 +3960,125 @@ jest-pnp-resolver@^1.2.2:
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
-jest-regex-util@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.4.0.tgz#e4c45b52653128843d07ad94aec34393ea14fbca"
-  integrity sha512-WeCpMpNnqJYMQoOjm1nTtsgbR4XHAk1u00qDoNBQoykM280+/TmgA5Qh5giC1ecy6a5d4hbSsHzpBtu5yvlbEg==
+jest-regex-util@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.5.0.tgz#26c26cf15a73edba13cb8930e261443d25ed8608"
+  integrity sha512-e9LqSd6HsDsqd7KS3rNyYwmQAaG9jq4U3LbnwVxN/y3nNlDzm2OFs596uo9zrUY+AV1opXq6ome78tRDUCRWfA==
 
-jest-resolve-dependencies@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.6.tgz#fc50ee56a67d2c2183063f6a500cc4042b5e2327"
-  integrity sha512-W85uJZcFXEVZ7+MZqIPCscdjuctruNGXUZ3OHSXOfXR9ITgbUKeHj+uGcies+0SsvI5GtUfTw4dY7u9qjTvQOw==
+jest-resolve-dependencies@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.5.0.tgz#8e3b15589848995ddc9a39f49462dad5b7bc14a2"
+  integrity sha512-xQsy7CmrT4CJxdNUEdzZU2M/v6YmtQ/pkJM+sx7TA1siG1zfsZuo78PZvzglwRMQFr88f3Su4Om8OEBAic+SMw==
   dependencies:
-    "@jest/types" "^27.4.2"
-    jest-regex-util "^27.4.0"
-    jest-snapshot "^27.4.6"
+    "@jest/types" "^27.5.0"
+    jest-regex-util "^27.5.0"
+    jest-snapshot "^27.5.0"
 
-jest-resolve@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.4.6.tgz#2ec3110655e86d5bfcfa992e404e22f96b0b5977"
-  integrity sha512-SFfITVApqtirbITKFAO7jOVN45UgFzcRdQanOFzjnbd+CACDoyeX7206JyU92l4cRr73+Qy/TlW51+4vHGt+zw==
+jest-resolve@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.5.0.tgz#a8e95a68dfb4a59faa508d7b6d2c6a02dcabb712"
+  integrity sha512-PkDpYEGV/nFqThnIrlPtj8oTxyAV3iuuS6or7dZYyUWaHr/tyyVb5qfBmZS6FEr7ozBHgjrF1bgcgIefnlicbw==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.6"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^27.5.0"
     jest-pnp-resolver "^1.2.2"
-    jest-util "^27.4.2"
-    jest-validate "^27.4.6"
+    jest-util "^27.5.0"
+    jest-validate "^27.5.0"
     resolve "^1.20.0"
     resolve.exports "^1.1.0"
     slash "^3.0.0"
 
-jest-runner@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.4.6.tgz#1d390d276ec417e9b4d0d081783584cbc3e24773"
-  integrity sha512-IDeFt2SG4DzqalYBZRgbbPmpwV3X0DcntjezPBERvnhwKGWTW7C5pbbA5lVkmvgteeNfdd/23gwqv3aiilpYPg==
+jest-runner@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.5.0.tgz#b5747a4444b4d3faae019bd201943948882d26c3"
+  integrity sha512-RMzXhkJLLOKKgUPY2trpyVBijaFmswMtgoCCBk2PQVRHC6yo1vLd1/jmFP39s5OXXnt7rntuzKSYvxl+QUibqQ==
   dependencies:
-    "@jest/console" "^27.4.6"
-    "@jest/environment" "^27.4.6"
-    "@jest/test-result" "^27.4.6"
-    "@jest/transform" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/console" "^27.5.0"
+    "@jest/environment" "^27.5.0"
+    "@jest/test-result" "^27.5.0"
+    "@jest/transform" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
     chalk "^4.0.0"
     emittery "^0.8.1"
-    exit "^0.1.2"
-    graceful-fs "^4.2.4"
-    jest-docblock "^27.4.0"
-    jest-environment-jsdom "^27.4.6"
-    jest-environment-node "^27.4.6"
-    jest-haste-map "^27.4.6"
-    jest-leak-detector "^27.4.6"
-    jest-message-util "^27.4.6"
-    jest-resolve "^27.4.6"
-    jest-runtime "^27.4.6"
-    jest-util "^27.4.2"
-    jest-worker "^27.4.6"
+    graceful-fs "^4.2.9"
+    jest-docblock "^27.5.0"
+    jest-environment-jsdom "^27.5.0"
+    jest-environment-node "^27.5.0"
+    jest-haste-map "^27.5.0"
+    jest-leak-detector "^27.5.0"
+    jest-message-util "^27.5.0"
+    jest-resolve "^27.5.0"
+    jest-runtime "^27.5.0"
+    jest-util "^27.5.0"
+    jest-worker "^27.5.0"
     source-map-support "^0.5.6"
     throat "^6.0.1"
 
-jest-runtime@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.4.6.tgz#83ae923818e3ea04463b22f3597f017bb5a1cffa"
-  integrity sha512-eXYeoR/MbIpVDrjqy5d6cGCFOYBFFDeKaNWqTp0h6E74dK0zLHzASQXJpl5a2/40euBmKnprNLJ0Kh0LCndnWQ==
+jest-runtime@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.5.0.tgz#2497116742b9e7cc1e5381a9ded36602b8b0c78c"
+  integrity sha512-T7APxCPjN3p3ePcLuypbWtD0UZHyAdvIADZ9ABI/sFZ9t/Rf2xIUd6D7RzZIX+unewJRooVGWrgDIgeUuj0OUA==
   dependencies:
-    "@jest/environment" "^27.4.6"
-    "@jest/fake-timers" "^27.4.6"
-    "@jest/globals" "^27.4.6"
-    "@jest/source-map" "^27.4.0"
-    "@jest/test-result" "^27.4.6"
-    "@jest/transform" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/environment" "^27.5.0"
+    "@jest/fake-timers" "^27.5.0"
+    "@jest/globals" "^27.5.0"
+    "@jest/source-map" "^27.5.0"
+    "@jest/test-result" "^27.5.0"
+    "@jest/transform" "^27.5.0"
+    "@jest/types" "^27.5.0"
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
     execa "^5.0.0"
     glob "^7.1.3"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.6"
-    jest-message-util "^27.4.6"
-    jest-mock "^27.4.6"
-    jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.6"
-    jest-snapshot "^27.4.6"
-    jest-util "^27.4.2"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^27.5.0"
+    jest-message-util "^27.5.0"
+    jest-mock "^27.5.0"
+    jest-regex-util "^27.5.0"
+    jest-resolve "^27.5.0"
+    jest-snapshot "^27.5.0"
+    jest-util "^27.5.0"
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
-jest-serializer@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.4.0.tgz#34866586e1cae2388b7d12ffa2c7819edef5958a"
-  integrity sha512-RDhpcn5f1JYTX2pvJAGDcnsNTnsV9bjYPU8xcV+xPwOXnUPOQwf4ZEuiU6G9H1UztH+OapMgu/ckEVwO87PwnQ==
+jest-serializer@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.5.0.tgz#439a110df27f97a40c114a429b708c2ada15a81f"
+  integrity sha512-aSDFqQlVXtBH+Zb5dl9mCvTSFkabixk/9P9cpngL4yJKpmEi9USxfDhONFMzJrtftPvZw3PcltUVmtFZTB93rg==
   dependencies:
     "@types/node" "*"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
 
-jest-snapshot@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.4.6.tgz#e2a3b4fff8bdce3033f2373b2e525d8b6871f616"
-  integrity sha512-fafUCDLQfzuNP9IRcEqaFAMzEe7u5BF7mude51wyWv7VRex60WznZIC7DfKTgSIlJa8aFzYmXclmN328aqSDmQ==
+jest-snapshot@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.5.0.tgz#c5c4c084f5e10036f31e7647de1a6f28c07681fc"
+  integrity sha512-cAJj15uqWGkro0bfcv/EgusBnqNgCpRruFQZghsMYTq4Fm2lk/VhAf8DgRr8wvhR6Ue1hkeL8tn70Cw4t8x/5A==
   dependencies:
     "@babel/core" "^7.7.2"
     "@babel/generator" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.0.0"
-    "@jest/transform" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/transform" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/babel__traverse" "^7.0.4"
     "@types/prettier" "^2.1.5"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^27.4.6"
-    graceful-fs "^4.2.4"
-    jest-diff "^27.4.6"
-    jest-get-type "^27.4.0"
-    jest-haste-map "^27.4.6"
-    jest-matcher-utils "^27.4.6"
-    jest-message-util "^27.4.6"
-    jest-util "^27.4.2"
+    expect "^27.5.0"
+    graceful-fs "^4.2.9"
+    jest-diff "^27.5.0"
+    jest-get-type "^27.5.0"
+    jest-haste-map "^27.5.0"
+    jest-matcher-utils "^27.5.0"
+    jest-message-util "^27.5.0"
+    jest-util "^27.5.0"
     natural-compare "^1.4.0"
-    pretty-format "^27.4.6"
+    pretty-format "^27.5.0"
     semver "^7.3.2"
 
 jest-util@^27.0.0:
@@ -4078,41 +4093,41 @@ jest-util@^27.0.0:
     is-ci "^3.0.0"
     picomatch "^2.2.3"
 
-jest-util@^27.4.2:
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.4.2.tgz#ed95b05b1adfd761e2cda47e0144c6a58e05a621"
-  integrity sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==
+jest-util@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.5.0.tgz#0b9540d91b0de65d288f235fa9899e6eeeab8d35"
+  integrity sha512-FUUqOx0gAzJy3ytatT1Ss372M1kmhczn8x7aE0++11oPGW1FyD/5NjYBI8w1KOXFm6IVjtaZm2szfJJL+CHs0g==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-validate@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.4.6.tgz#efc000acc4697b6cf4fa68c7f3f324c92d0c4f1f"
-  integrity sha512-872mEmCPVlBqbA5dToC57vA3yJaMRfIdpCoD3cyHWJOMx+SJwLNw0I71EkWs41oza/Er9Zno9XuTkRYCPDUJXQ==
+jest-validate@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.5.0.tgz#b3df32372d2c832fa5a5e31ee2c37f94f79f7f1f"
+  integrity sha512-2XZzQWNrY9Ypo11mm4ZeVjvr++CQG/45XnmA2aWwx155lTwy1JGFI8LpQ2dBCSAeO21ooqg/FCIvv9WwfnPClA==
   dependencies:
-    "@jest/types" "^27.4.2"
+    "@jest/types" "^27.5.0"
     camelcase "^6.2.0"
     chalk "^4.0.0"
-    jest-get-type "^27.4.0"
+    jest-get-type "^27.5.0"
     leven "^3.1.0"
-    pretty-format "^27.4.6"
+    pretty-format "^27.5.0"
 
-jest-watcher@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.4.6.tgz#673679ebeffdd3f94338c24f399b85efc932272d"
-  integrity sha512-yKQ20OMBiCDigbD0quhQKLkBO+ObGN79MO4nT7YaCuQ5SM+dkBNWE8cZX0FjU6czwMvWw6StWbe+Wv4jJPJ+fw==
+jest-watcher@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.5.0.tgz#ca11c3b9115c92a8fd2fd9e2def296d45206f1ca"
+  integrity sha512-MhIeIvEd6dnnspE0OfYrqHOAfZZdyFqx/k8U2nvVFSkLYf22qAFfyNWPVQYcwqKVNobcOhJoT0kV/nRHGbqK8A==
   dependencies:
-    "@jest/test-result" "^27.4.6"
-    "@jest/types" "^27.4.2"
+    "@jest/test-result" "^27.5.0"
+    "@jest/types" "^27.5.0"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
-    jest-util "^27.4.2"
+    jest-util "^27.5.0"
     string-length "^4.0.1"
 
 jest-worker@^26.3.0:
@@ -4124,23 +4139,23 @@ jest-worker@^26.3.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest-worker@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.6.tgz#5d2d93db419566cb680752ca0792780e71b3273e"
-  integrity sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==
+jest-worker@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.0.tgz#99ee77e4d06168107c27328bd7f54e74c3a48d59"
+  integrity sha512-8OEHiPNOPTfaWnJ2SUHM8fmgeGq37uuGsQBvGKQJl1f+6WIy6g7G3fE2ruI5294bUKUI9FaCWt5hDvO8HSwsSg==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@27.4.7:
-  version "27.4.7"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.4.7.tgz#87f74b9026a1592f2da05b4d258e57505f28eca4"
-  integrity sha512-8heYvsx7nV/m8m24Vk26Y87g73Ba6ueUd0MWed/NXMhSZIm62U/llVbS0PJe1SHunbyXjJ/BqG1z9bFjGUIvTg==
+jest@27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-27.5.0.tgz#2c04ff88754e42e9fc5240840b91f9a9a8990875"
+  integrity sha512-sCMZhL9zy0fiFc4H0cKlXq7BcghMSxm5ZnEyaPWTteArU5ix6JjOKyOXSUBGLTQCmt5kuX9zEvQ9BSshHOPB3A==
   dependencies:
-    "@jest/core" "^27.4.7"
+    "@jest/core" "^27.5.0"
     import-local "^3.0.2"
-    jest-cli "^27.4.7"
+    jest-cli "^27.5.0"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -4829,10 +4844,10 @@ pretty-format@^27.0.2:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.6.tgz#1b784d2f53c68db31797b2348fa39b49e31846b7"
-  integrity sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==
+pretty-format@^27.5.0:
+  version "27.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.0.tgz#71e1af7a4b587d259fa4668dcd3e94af077767cb"
+  integrity sha512-xEi6BRPZ+J1AIS4BAtFC/+rh5jXlXObGZjx5+OSpM95vR/PGla78bFVHMy5GdZjP9wk3AHAMHROXq/r69zXltw==
   dependencies:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"


### PR DESCRIPTION
As `config` was an export, the value seen by imports was never updated, even after reconfiguring, as imported values are not live. 

This is fixed by introducing a getter.

I believe this only happened for people not using swc, but I did not dig into it.

The fix for users here is to upgrade to v2.0.6 which I'll release in a bit.

relates to https://github.com/happykit/flags/issues/23