### PR TITLE
fix: access hkvk cookie value properly in next 13

### DIFF
--- a/.changeset/tidy-moons-lick.md
+++ b/.changeset/tidy-moons-lick.md
@@ -1,0 +1,5 @@
+---
+"@happykit/flags": patch
+---
+
+Update the cookie logic to work with Next.js 13.

--- a/package/src/edge.spec.ts
+++ b/package/src/edge.spec.ts
@@ -259,4 +259,68 @@ describe("middleware", () => {
       });
     });
   });
+
+  describe("when request cookies are an object", () => {
+    it("gets the cookie value", async () => {
+      fetchMock.post(
+        {
+          url: "https://happykit.dev/api/flags/flags_pub_000000",
+          body: {
+            traits: null,
+            user: null,
+            visitorKey: "V1StGXR8_Z5jdHi6B-myT",
+          },
+        },
+        {
+          headers: { "content-type": "application/json" },
+          body: {
+            flags: { meal: "large" },
+            visitor: { key: "V1StGXR8_Z5jdHi6B-myT" },
+          },
+        }
+      );
+
+      const request = createNextRequest({
+        cookies: { hkvk: { name: "hkvk", value: "V1StGXR8_Z5jdHi6B-myT" } },
+      });
+
+      expect(
+        await getEdgeFlags({ request })
+      ).toEqual({
+        flags: { meal: "large" },
+        data: {
+          flags: { meal: "large" },
+          visitor: { key: "V1StGXR8_Z5jdHi6B-myT" },
+        },
+        error: null,
+        initialFlagState: {
+          input: {
+            endpoint: "https://happykit.dev/api/flags",
+            envKey: "flags_pub_000000",
+            requestBody: {
+              traits: null,
+              user: null,
+              visitorKey: "V1StGXR8_Z5jdHi6B-myT",
+            },
+          },
+          outcome: {
+            data: {
+              flags: { meal: "large" },
+              visitor: { key: "V1StGXR8_Z5jdHi6B-myT" },
+            },
+          },
+        },
+        cookie: {
+          args: [
+            "hkvk",
+            "V1StGXR8_Z5jdHi6B-myT",
+            { maxAge: 15552000, path: "/", sameSite: "lax" },
+          ],
+          name: "hkvk",
+          options: { maxAge: 15552000, path: "/", sameSite: "lax" },
+          value: "V1StGXR8_Z5jdHi6B-myT",
+        },
+      });
+    });
+  });
 });

--- a/package/src/edge.ts
+++ b/package/src/edge.ts
@@ -67,13 +67,13 @@ export function createGetEdgeFlags<F extends Flags>(
     let visitorKeyFromCookie;
     if (typeof options.request.cookies.get === "function") {
       const fromCookiesGet = options.request.cookies.get("hkvk");
-      
-      // In Next.js 13, the value returned from cookies.get() is an object with the type: { name: string, value: string }
+
+      // @ts-expect-error -- In Next.js 13, the value returned from cookies.get() is an object with the type: { name: string, value: string }
       visitorKeyFromCookie = typeof fromCookiesGet === 'string' ? fromCookiesGet : fromCookiesGet?.value;
     } else {
       // backwards compatible for when cookies was { [key: string]: string; }
       // in Next.js
-      visitorKeyFromCokoie = (options.request.cookies as any).hkvk || null;
+      visitorKeyFromCookie = (options.request.cookies as any).hkvk || null;
     }
 
     // When using server-side rendering and there was no visitor key cookie,

--- a/package/src/edge.ts
+++ b/package/src/edge.ts
@@ -64,12 +64,17 @@ export function createGetEdgeFlags<F extends Flags>(
       : factoryGetDefinitions;
 
     // determine visitor key
-    const visitorKeyFromCookie =
-      typeof options.request.cookies.get === "function"
-        ? options.request.cookies.get("hkvk")
-        : // backwards compatible for when cookies was { [key: string]: string; }
-          // in Next.js
-          (options.request.cookies as any).hkvk || null;
+    let visitorKeyFromCookie;
+    if (typeof options.request.cookies.get === "function") {
+      const fromCookiesGet = options.request.cookies.get("hkvk");
+      
+      // In Next.js 13, the value returned from cookies.get() is an object with the type: { name: string, value: string }
+      visitorKeyFromCookie = typeof fromCookiesGet === 'string' ? fromCookiesGet : fromCookiesGet?.value;
+    } else {
+      // backwards compatible for when cookies was { [key: string]: string; }
+      // in Next.js
+      visitorKeyFromCokoie = (options.request.cookies as any).hkvk || null;
+    }
 
     // When using server-side rendering and there was no visitor key cookie,
     // we generate a visitor key


### PR DESCRIPTION
In Next 13, `cookies.get()` returns an object of the shape `{ name, value}` ([docs](https://nextjs.org/docs/advanced-features/middleware#using-cookies)). This fix updates the logic to handle this so using flags in middleware works as expected when a visitor already has a `hkvk` cookie.